### PR TITLE
chore(release): prepare 0.24.0

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to push to the tap (e.g. 0.23.0)"
+        description: "Version to push to the tap (e.g. 0.24.0)"
         required: true
         type: string
 

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.23.0)"
+        description: "Version to build (e.g. 0.24.0)"
         required: true
         type: string
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.23.0)"
+        description: "Version to build (e.g. 0.24.0)"
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.24.0 (2026-05-28)
+
+### What changed in this release
+
+- **Update prompt is now wired and highlighted.** The blocking 4-choice update menu (Update now / Skip / Dismiss / Exit) was defined but never invoked at shell startup — users only ever saw the passive bottom-bar toast. It now runs before the auto-update path in every interactive session. The persistent status-line update notice also renders in bold bright-yellow so it is harder to miss.
+- **Complete native installer `Fetch` fix.** The 0.23.0 release bundled trafilatura's data files but missed `justext`'s stoplists directory, so the `Fetch` tool still crashed with `FileNotFoundError: ./_MEIxxxx/justext/stoplists` on `.exe`, `.deb`, and `.rpm` installs. All three installer specs now bundle both `trafilatura` and `justext` data files. PyPI / `pip install` was unaffected.
+- **Atomic "latest" release gating.** The GitHub Release is no longer marked "latest" until every platform asset (4 archives, 1 `.exe`, 4 `.deb`/`.rpm`) is attached. A dispatch workflow polls for completeness before flipping the flag, so `/releases/latest` and the in-app updater no longer serve a partially-built release during the publish window.
+- **Smarter `/update` command.** `run_update_prompt` now routes through `do_update(check_only=True)` to get a fresh PyPI version before showing the update modal, and verifies that the expected binary asset for your platform exists on the GitHub Release before initiating a native upgrade.
+- **Repository transferred to TechMatrix-labs.** All GitHub URLs, install script references, and CI configuration now point to `github.com/TechMatrix-labs/pythinker-code`.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.24.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.23.0 (2026-05-28)
 
 ### What changed in this release

--- a/README.md
+++ b/README.md
@@ -50,11 +50,15 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.23.0
+## 🆕 What's New in 0.24.0
 
-- **Fetch works again in native installers.** Homebrew, `.deb`, `.rpm`, and `PythinkerSetup-*.exe` binaries shipped without `trafilatura/settings.cfg`, so the first `Fetch` call crashed with `No option 'min_extracted_size' in section: 'DEFAULT'`. The PyInstaller spec now bundles trafilatura's data files. PyPI / `pip install` was unaffected.
+- **Update prompt is now wired and highlighted.** The blocking 4-choice update menu was defined but never invoked — users only ever saw the passive toast. It now runs before the auto-update path in every interactive session, and the status-line notice renders in bold bright-yellow.
+- **Complete native installer `Fetch` fix.** The `.exe`, `.deb`, and `.rpm` builds now bundle both `trafilatura` and `justext` data files so `Fetch` no longer crashes with `FileNotFoundError` on stoplists in native installs. PyPI / `pip install` was unaffected.
+- **Atomic "latest" release gating.** `/releases/latest` is no longer flipped until every platform asset is attached, preventing the in-app updater from serving a partially-built release.
+- **Smarter `/update` command.** Gets a fresh PyPI version and verifies the platform binary exists on the release before initiating a native upgrade.
+- **Repository transferred to TechMatrix-labs.** All URLs now point to `github.com/TechMatrix-labs/pythinker-code`.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.23.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.24.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -144,7 +148,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.23.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.24.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install TechMatrix-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **<img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux"> — system package** | Download the `.deb` or `.rpm` for your distro below | [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
@@ -169,7 +173,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.23.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.24.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -180,13 +184,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.23.0.exe
+.\PythinkerSetup-0.24.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.23.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.24.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -237,26 +241,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.23.0_amd64.deb
+sudo dpkg -i pythinker-code_0.24.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.23.0_arm64.deb
+sudo dpkg -i pythinker-code_0.24.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code-0.23.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code-0.23.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.23.0.x86_64.rpm.sha256
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.24.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.23.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.24.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.23.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.24.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code-0.23.0.aarch64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code-0.23.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.23.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.23.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.24.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.24.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -265,8 +269,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.23.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.23.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.24.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.24.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /
@@ -296,7 +300,7 @@ at `~/.local/bin/pythinker`.
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.23.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.23.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.23.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.24.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -2,6 +2,10 @@
 
 This page documents breaking changes in Pythinker Code releases and provides migration guidance.
 
+## 0.24.0 (2026-05-28)
+
+No breaking changes. This release is compatible with 0.23.0 user configuration, native installs, and session data.
+
 ## 0.23.0 (2026-05-28)
 
 No breaking changes. This release is compatible with 0.22.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,18 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.24.0 (2026-05-28)
+
+### What changed in this release
+
+- **Update prompt is now wired and highlighted.** The blocking 4-choice update menu (Update now / Skip / Dismiss / Exit) was defined but never invoked at shell startup — users only ever saw the passive bottom-bar toast. It now runs before the auto-update path in every interactive session. The persistent status-line update notice also renders in bold bright-yellow so it is harder to miss.
+- **Complete native installer `Fetch` fix.** The 0.23.0 release bundled trafilatura's data files but missed `justext`'s stoplists directory, so the `Fetch` tool still crashed with `FileNotFoundError: ./_MEIxxxx/justext/stoplists` on `.exe`, `.deb`, and `.rpm` installs. All three installer specs now bundle both `trafilatura` and `justext` data files. PyPI / `pip install` was unaffected.
+- **Atomic "latest" release gating.** The GitHub Release is no longer marked "latest" until every platform asset (4 archives, 1 `.exe`, 4 `.deb`/`.rpm`) is attached. A dispatch workflow polls for completeness before flipping the flag, so `/releases/latest` and the in-app updater no longer serve a partially-built release during the publish window.
+- **Smarter `/update` command.** `run_update_prompt` now routes through `do_update(check_only=True)` to get a fresh PyPI version before showing the update modal, and verifies that the expected binary asset for your platform exists on the GitHub Release before initiating a native upgrade.
+- **Repository transferred to TechMatrix-labs.** All GitHub URLs, install script references, and CI configuration now point to `github.com/TechMatrix-labs/pythinker-code`.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.24.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.23.0 (2026-05-28)
 
 ### What changed in this release

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.23.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.24.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.23.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/packages/homebrew-tap/generate-formula.py
+++ b/packages/homebrew-tap/generate-formula.py
@@ -7,7 +7,7 @@ resources.
 
 Usage:
     python generate-formula.py \
-        --version 0.23.0 \
+        --version 0.24.0 \
         --template packages/homebrew-tap/pythinker-code.rb.tmpl \
         --output Formula/pythinker-code.rb
 """

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code_0.23.0_amd64.deb
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code_0.23.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.23.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.23.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code_0.24.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code_0.24.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.24.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.24.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code-0.23.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.23.0/pythinker-code-0.23.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.23.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.23.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.24.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.24.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.23.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.24.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.23.0
+bash packages/linux-installer/build.sh 0.24.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.23.0_amd64.deb`
-- `pythinker-code-0.23.0.x86_64.rpm`
+- `pythinker-code_0.24.0_amd64.deb`
+- `pythinker-code-0.24.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.23.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.24.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.23.0"
+version = "0.24.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/install-native.sh
+++ b/scripts/install-native.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.23.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.23.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.24.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2402,7 +2402,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },

--- a/web/public/install.ps1
+++ b/web/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.23.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.24.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.23.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker


### PR DESCRIPTION
## Summary

- Bump version `0.23.0` → `0.24.0` across all 18 release files
- Add `## 0.24.0 (2026-05-28)` CHANGELOG block covering: update prompt wiring, complete native installer Fetch fix (justext stoplists), atomic "latest" gating, smarter `/update` command, and TechMatrix-labs org transfer
- No breaking changes

## Changes

Exactly 18 files — matching the previous release commit scope:
- `pyproject.toml`, `uv.lock`: version bump
- `CHANGELOG.md`, `docs/en/release-notes/changelog.md`: new 0.24.0 block
- `docs/en/release-notes/breaking-changes.md`: new 0.24.0 no-breaking-changes entry
- `README.md`: What's New section updated, all asset filenames and version references bumped
- 11 install scripts / workflow files: mechanical version bump

## Test plan

- [x] `check_version_tag.py --expected-version 0.24.0` passes
- [x] README `What's New in 0.24.0` and `pythinker-code==0.24.0` present
- [x] `CHANGELOG.md` has `## 0.24.0 (` entry
- [x] `check_pythinker_dependency_versions.py` passes
- [x] `tests/test_installation_docs.py tests/test_homebrew_formula.py` — 16 passed
- [x] No stray `0.23.0` references outside historical CHANGELOG/breaking-changes entries