### PR TITLE
chore(deps): bump rich from 14.2.0 to 15.0.0 across workspace

### DIFF
--- a/packages/pythinker-review/pyproject.toml
+++ b/packages/pythinker-review/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "typer==0.21.1",
     "pydantic>=2.12.5",
     "pyyaml==6.0.3",
-    "rich==14.2.0",
+    "rich==15.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "prompt-toolkit==3.0.52",
     "pillow==12.2.0",
     "pyyaml==6.0.3",
-    "rich==14.2.0",
+    "rich==15.0.0",
     "certifi>=2025.10.5",
     "click==8.3.0",
     "pyperclip==1.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2481,7 +2481,7 @@ requires-dist = [
     { name = "pythinker-host", editable = "packages/pythinker-host" },
     { name = "pythinker-review", editable = "packages/pythinker-review" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "rich", specifier = "==14.2.0" },
+    { name = "rich", specifier = "==15.0.0" },
     { name = "scalar-fastapi", specifier = ">=1.8.2" },
     { name = "sentry-sdk", specifier = ">=2.20,<3" },
     { name = "setproctitle", specifier = ">=1.3.0" },
@@ -2627,7 +2627,7 @@ dev = [
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "rich", specifier = "==14.2.0" },
+    { name = "rich", specifier = "==15.0.0" },
     { name = "typer", specifier = "==0.21.1" },
 ]
 
@@ -2952,15 +2952,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.2.0"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `rich` from `14.2.0` to `15.0.0` in **both** `pyproject.toml` and `packages/pythinker-review/pyproject.toml`
- Regenerates `uv.lock`

Closes/replaces dependabot PR #1 which only bumped the top-level package, causing an unsatisfiable workspace dependency conflict and failing CI everywhere.

## Why it's safe

rich 15.0.0's only breaking change is **dropped Python 3.8 support** (EOL Oct 2024). No API changes. This project requires Python ≥ 3.12.

pythinker-review's usage is limited to `rich.console.Console` and `rich.markup.escape` — both unchanged in 15.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `rich` library dependency to the latest version (15.0.0).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TechMatrix-labs/pythinker-code/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->