### PR TITLE
fix(lint): migrate str+Enum to StrEnum; use PEP 695 type params

### DIFF
--- a/packages/pythinker-review/src/pythinker_review/cli/_shared.py
+++ b/packages/pythinker-review/src/pythinker_review/cli/_shared.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 from pythinker_review.store.models import SEVERITY_ORDER, Finding, RunMeta, Severity
 
 
-class OutputFormat(str, Enum):
+class OutputFormat(StrEnum):
     pretty = "pretty"
     json = "json"
     sarif = "sarif"
 
 
-class FailOn(str, Enum):
+class FailOn(StrEnum):
     critical = "critical"
     high = "high"
     medium = "medium"

--- a/packages/pythinker-review/src/pythinker_review/cli/review.py
+++ b/packages/pythinker-review/src/pythinker_review/cli/review.py
@@ -11,7 +11,7 @@ import re
 import sys
 import tomllib
 from collections.abc import Callable, Sequence
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -82,22 +82,22 @@ from pythinker_review.store.models import SEVERITY_ORDER, Finding, Pass, RunMeta
 app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
-class ReviewMode(str, Enum):
+class ReviewMode(StrEnum):
     default = "default"
     deslopify = "deslopify"
 
 
-class ArtifactFormat(str, Enum):
+class ArtifactFormat(StrEnum):
     pretty = "pretty"
     json = "json"
 
 
-class DiffSide(str, Enum):
+class DiffSide(StrEnum):
     right = "RIGHT"
     left = "LEFT"
 
 
-class SimilarIssuesBackend(str, Enum):
+class SimilarIssuesBackend(StrEnum):
     chroma = "chroma"
     lexical = "lexical"
     auto = "auto"

--- a/packages/pythinker-review/src/pythinker_review/engine/diff_source.py
+++ b/packages/pythinker-review/src/pythinker_review/engine/diff_source.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
 _GIT_TIMEOUT_S = 20.0
 
 
-class DiffMode(str, Enum):
+class DiffMode(StrEnum):
     base = "base"
     staged = "staged"
     working_tree = "working_tree"

--- a/packages/pythinker-review/src/pythinker_review/store/models.py
+++ b/packages/pythinker-review/src/pythinker_review/store/models.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class Severity(str, Enum):
+class Severity(StrEnum):
     critical = "critical"
     high = "high"
     medium = "medium"
@@ -26,7 +26,7 @@ SEVERITY_ORDER: dict[Severity, int] = {
 }
 
 
-class Category(str, Enum):
+class Category(StrEnum):
     correctness = "correctness"
     security = "security"
     debugging = "debugging"

--- a/tests/core/test_pythinkersoul_ralph_loop.py
+++ b/tests/core/test_pythinkersoul_ralph_loop.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
-from typing import Self, TypeVar
+from typing import Self
 
 import pytest
 from inline_snapshot import Snapshot, snapshot
@@ -31,7 +31,6 @@ def approval() -> Approval:
     return Approval(yolo=False)
 
 
-T = TypeVar("T")
 RALPH_IMAGE_URL = "https://example.com/test.png"
 RALPH_IMAGE_USER_INPUT = [
     TextPart(text="Check this image"),
@@ -39,7 +38,7 @@ RALPH_IMAGE_USER_INPUT = [
 ]
 
 
-def expect_snapshot(value: T, expected: Snapshot[T]) -> None:
+def expect_snapshot[T](value: T, expected: Snapshot[T]) -> None:
     if expected != value:
         pytest.fail(f"Snapshot mismatch: {value!r} != {expected!r}")
 


### PR DESCRIPTION
## Summary

- Replaces `class Foo(str, Enum)` with `class Foo(StrEnum)` across 4 files in `pythinker-review` (9 enums total) to fix UP042
- Replaces `TypeVar("T")` with PEP 695 type-parameter syntax in the ralph-loop test to fix UP047
- All targets are Python 3.12+, so both `StrEnum` (3.11+) and PEP 695 (3.12+) are fully supported

## Motivation

Unblocks the ruff 0.15 Dependabot bump (PR #4). Ruff 0.15 enabled UP042 and UP047 by default, which flagged 10 violations in existing code.

## Test plan

- [ ] CI `check` job passes (ruff UP042/UP047 clean)
- [ ] All existing tests pass (no behavioral change — StrEnum is a drop-in for `str+Enum` when values are explicit strings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal enum implementations to use modern Python patterns for improved code consistency.
  * Modernized generic type annotations to align with current Python language standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TechMatrix-labs/pythinker-code/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->