### PR TITLE
chore(release): prepare 0.25.0

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to push to the tap (e.g. 0.24.0)"
+        description: "Version to push to the tap (e.g. 0.25.0)"
         required: true
         type: string
 

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.24.0)"
+        description: "Version to build (e.g. 0.25.0)"
         required: true
         type: string
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.24.0)"
+        description: "Version to build (e.g. 0.25.0)"
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.25.0 (2026-05-29)
+
+### What changed in this release
+
+- **`Fetch` now re-checks every redirect hop against the SSRF guard.** Redirects were followed without re-validating the destination, so a public URL could redirect to a link-local address (e.g. a cloud metadata endpoint) and slip past the guard that only inspected the original URL. Redirects are now followed manually and every hop is re-validated, closing the public→link-local bypass.
+- **Web domain allowlist for `Fetch` and `Search`.** A new `web.allowed_domains` config option restricts which hosts the web tools may reach. When set, `Fetch` (including every redirect hop) and `Search` reject any host outside the list; leave it unset to keep web access unrestricted.
+- **Crash-consistent background tasks.** Task and agent-task state is now serialised under a cross-process per-task lock, so a worker heartbeat landing mid-update is no longer lost. Every terminal agent-task update routes through a single finalizer that writes the authoritative runtime first, and recovery reconciles records left divergent by a crash or kill without ever clobbering a live agent. Bash task output is capped (default 50 MiB) so a chatty task cannot exhaust disk, terminated processes get a SIGTERM→SIGKILL fallback, and aged terminal task directories are pruned (default 7 days).
+- **Calmer, more reliable TUI.** The todo list no longer renders twice during an in-flight turn, OAuth and feedback links open through a detached browser launcher so browser output cannot corrupt the terminal or steal key presses, and the terminal is restored to a sane state on `SIGTERM`/`SIGQUIT` and at exit.
+- **Live tool-execution feedback.** Tool calls now show a calm "preparing" row during approval and hooks, switch to a live status once execution starts, and stream shell `stdout`/`stderr` as a running tail before the final result lands. The composing assistant block renders a live Markdown preview as the model writes, code blocks gain clearer framing, and the active spinner uses smoother braille dots.
+- **Steadier agent loop.** The model is nudged once when a turn ends on a bare statement of intent with no tool call, steered away from blocking on a single background task while siblings are still running, and a `SetTodoList` call whose todos arrive as a JSON-encoded string is now parsed transparently instead of failing validation.
+- **Unified report rendering.** Code review, verify, and security-review output now share one standardized, muted report renderer — including `report` blocks emitted by skills and agents; a malformed block falls back to ordinary markdown rather than being swallowed.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.25.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.24.0 (2026-05-28)
 
 ### What changed in this release

--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.24.0
+## 🆕 What's New in 0.25.0
 
-- **Update prompt is now wired and highlighted.** The blocking 4-choice update menu was defined but never invoked — users only ever saw the passive toast. It now runs before the auto-update path in every interactive session, and the status-line notice renders in bold bright-yellow.
-- **Complete native installer `Fetch` fix.** The `.exe`, `.deb`, and `.rpm` builds now bundle both `trafilatura` and `justext` data files so `Fetch` no longer crashes with `FileNotFoundError` on stoplists in native installs. PyPI / `pip install` was unaffected.
-- **Atomic "latest" release gating.** `/releases/latest` is no longer flipped until every platform asset is attached, preventing the in-app updater from serving a partially-built release.
-- **Smarter `/update` command.** Gets a fresh PyPI version and verifies the platform binary exists on the release before initiating a native upgrade.
-- **Repository transferred to TechMatrix-labs.** All URLs now point to `github.com/TechMatrix-labs/pythinker-code`.
+- **`Fetch` re-checks every redirect hop against the SSRF guard.** Redirects were followed without re-validating the destination, so a public URL could redirect to a link-local address (e.g. a cloud metadata endpoint) and slip past the guard. Every hop is now re-validated, closing the public→link-local bypass.
+- **Web domain allowlist for `Fetch` and `Search`.** Set `web.allowed_domains` to restrict which hosts the web tools may reach — `Fetch` (every redirect hop included) and `Search` reject anything off the list. Leave it unset to keep web access unrestricted.
+- **Crash-consistent background tasks.** Task state is serialised under a cross-process lock, terminal updates route through a single finalizer, and recovery reconciles records left divergent by a crash or kill without clobbering a live agent. Bash output is capped (default 50 MiB), kills escalate SIGTERM→SIGKILL, and aged terminal tasks are pruned (default 7 days).
+- **Calmer TUI with live tool feedback.** Tool calls show a "preparing" row during approval, stream shell output as a running tail, and render a live Markdown preview as the model writes. The todo list no longer renders twice mid-turn, links open through a detached launcher, and the terminal is restored to a sane state on `SIGTERM`/`SIGQUIT` and at exit.
+- **Steadier agent loop.** The model is nudged when a turn ends on a bare statement of intent, steered away from blocking on one background task while siblings run, and a `SetTodoList` whose todos arrive as a JSON string is parsed transparently instead of failing validation.
+- **Unified report rendering.** Code review, verify, and security-review output share one standardized renderer, including `report` blocks emitted by skills and agents.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.24.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.25.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -148,7 +149,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.24.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.25.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install TechMatrix-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **<img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux"> — system package** | Download the `.deb` or `.rpm` for your distro below | [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
@@ -173,7 +174,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.24.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.25.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -184,13 +185,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.24.0.exe
+.\PythinkerSetup-0.25.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.24.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.25.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -241,26 +242,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.24.0_amd64.deb
+sudo dpkg -i pythinker-code_0.25.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.24.0_arm64.deb
+sudo dpkg -i pythinker-code_0.25.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.24.0.x86_64.rpm.sha256
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.25.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.24.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.25.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.24.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.25.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.aarch64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.24.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.24.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.25.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.25.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -269,8 +270,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.24.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.24.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.25.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.25.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /
@@ -300,7 +301,7 @@ at `~/.local/bin/pythinker`.
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.24.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.25.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -2,6 +2,10 @@
 
 This page documents breaking changes in Pythinker Code releases and provides migration guidance.
 
+## 0.25.0 (2026-05-29)
+
+No breaking changes. This release is compatible with 0.24.0 user configuration, native installs, and session data.
+
 ## 0.24.0 (2026-05-28)
 
 No breaking changes. This release is compatible with 0.23.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,20 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.25.0 (2026-05-29)
+
+### What changed in this release
+
+- **`Fetch` now re-checks every redirect hop against the SSRF guard.** Redirects were followed without re-validating the destination, so a public URL could redirect to a link-local address (e.g. a cloud metadata endpoint) and slip past the guard that only inspected the original URL. Redirects are now followed manually and every hop is re-validated, closing the public→link-local bypass.
+- **Web domain allowlist for `Fetch` and `Search`.** A new `web.allowed_domains` config option restricts which hosts the web tools may reach. When set, `Fetch` (including every redirect hop) and `Search` reject any host outside the list; leave it unset to keep web access unrestricted.
+- **Crash-consistent background tasks.** Task and agent-task state is now serialised under a cross-process per-task lock, so a worker heartbeat landing mid-update is no longer lost. Every terminal agent-task update routes through a single finalizer that writes the authoritative runtime first, and recovery reconciles records left divergent by a crash or kill without ever clobbering a live agent. Bash task output is capped (default 50 MiB) so a chatty task cannot exhaust disk, terminated processes get a SIGTERM→SIGKILL fallback, and aged terminal task directories are pruned (default 7 days).
+- **Calmer, more reliable TUI.** The todo list no longer renders twice during an in-flight turn, OAuth and feedback links open through a detached browser launcher so browser output cannot corrupt the terminal or steal key presses, and the terminal is restored to a sane state on `SIGTERM`/`SIGQUIT` and at exit.
+- **Live tool-execution feedback.** Tool calls now show a calm "preparing" row during approval and hooks, switch to a live status once execution starts, and stream shell `stdout`/`stderr` as a running tail before the final result lands. The composing assistant block renders a live Markdown preview as the model writes, code blocks gain clearer framing, and the active spinner uses smoother braille dots.
+- **Steadier agent loop.** The model is nudged once when a turn ends on a bare statement of intent with no tool call, steered away from blocking on a single background task while siblings are still running, and a `SetTodoList` call whose todos arrive as a JSON-encoded string is now parsed transparently instead of failing validation.
+- **Unified report rendering.** Code review, verify, and security-review output now share one standardized, muted report renderer — including `report` blocks emitted by skills and agents; a malformed block falls back to ordinary markdown rather than being swallowed.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.25.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.24.0 (2026-05-28)
 
 ### What changed in this release
@@ -102,6 +116,120 @@ Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.18.0`,
 - **Provider compatibility refresh.** Anthropic SDK support is updated for 0.101 tool-result block types so direct Anthropic sessions continue to stream tool output correctly.
 
 Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.17.0`, or use the native installer for your OS (see the README install table).
+
+## 0.16.0 (2026-05-24)
+
+### What changed in this release
+
+- **Standardized native install docs across platforms.** README Quick Start now presents one canonical Windows command (`irm https://pythinker.com/install.ps1 | iex`) and one canonical macOS/Linux command (`curl -fsSL https://pythinker.com/install.sh | bash`) before package-manager/manual alternatives.
+- **Removed old local installer guidance.** User-facing docs no longer advertise legacy local shell wrappers or Python-tool manager shortcuts. `pip install pythinker-code==0.16.0` remains as the universal Python fallback and release-gate snippet.
+- **Aligned release artifact instructions.** Manual Windows, Linux package, and tarball sections all point at `0.16.0` GitHub Release assets and keep SHA-256 verification explicit.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.16.0`, or use the native installer for your OS (see the README install table).
+
+## 0.15.0 (2026-05-24)
+
+### What changed in this release
+
+- **Fixed `pythinker update` for curl-bash native installs.** Frozen onefile installs in `~/.local/bin/pythinker` are now detected as native even when older tarballs do not include the `.pythinker-native` sentinel, avoiding the broken `pythinker -m pip install --upgrade pythinker-code` path.
+- **Added Unix native archive updating.** Linux and Apple Silicon macOS native builds now download the matching GitHub Release tarball, verify its `.sha256`, extract `pythinker`, and replace the current executable in place.
+- **Improved native update guidance.** The update banner now shows the canonical fixed-version curl installer on Unix and keeps the Windows installer guidance for Windows native builds.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.15.0`, or use the native installer for your OS (see the README install table).
+
+## 0.14.0 (2026-05-24)
+
+### What changed in this release
+
+- **Install counter and README badge.** `https://pythinker.com/install.sh` and `https://pythinker.com/install.ps1` now route through a Cloudflare Worker-backed counter that records successful installer fetches and exposes both JSON and Shields-compatible badge endpoints. The README now shows the live install badge alongside PyPI downloads.
+- **Canonical installer endpoint polish.** The hosted shell endpoint is the documented curl-bash path, the Windows PowerShell endpoint is documented as the native bootstrap, and pinned install examples now target `0.14.0` artifacts.
+- **TUI activity and readability refinements.** Tool/agent headers use calmer grey styling, agent task names resolve at call time, live spinner rows stay pinned while status output clips, oversized output is capped, markdown rendering is cleaner, and shell activity indicators are more stable.
+- **Release and CI hardening.** Plugin downloads are stricter, pythinker-home sync dispatch now skips when its optional repository-dispatch secret is absent instead of failing the main branch, and release documentation was refreshed for the native installer flow.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.14.0`, or use the native installer for your OS (see the README install table).
+
+## 0.13.0 (2026-05-22)
+
+### What changed in this release
+
+- **Native installers for macOS and Linux.** `brew install TechMatrix-labs/pythinker/pythinker-code` (Homebrew tap) covers both macOS (Intel + Apple Silicon) and Linux brew installs from a single auto-generated formula. Debian/Ubuntu users get `pythinker-code_x.y.z_<arch>.deb` and Fedora/RHEL/openSUSE users get `pythinker-code-x.y.z.<arch>.rpm`, both attached to every GitHub Release for `x86_64` and `aarch64`. Together with the Windows `PythinkerSetup-x.y.z.exe` shipped in 0.12.0, Pythinker now ships native installers for every supported platform — no Python, Node, or `uv` prerequisite.
+- **Cross-OS curl-bash native installer.** `curl -fsSL https://raw.githubusercontent.com/TechMatrix-labs/pythinker-code/main/scripts/install-native.sh | bash` detects your OS + arch, downloads the matching PyInstaller-frozen tarball from the latest Release, verifies its SHA-256, and lands the binary at `~/.local/bin/pythinker`. Supports `linux-x86_64`, `linux-aarch64`, and `macos-arm64`. Honors `--version`, `--prefix`, and `NO_COLOR`.
+- **Homebrew tap auto-published on every release.** A new `.github/workflows/homebrew-tap.yml` waits for the PyPI publish to land, runs an in-tree formula generator (replaces the unmaintained `homebrew-pypi-poet` — see release notes for the why), and pushes `Formula/pythinker-code.rb` to the `homebrew-pythinker` tap repo. 132 transitive deps are enumerated automatically — no hand-curation per release.
+- **Tag-triggered Linux package pipeline.** A new `.github/workflows/linux-installer.yml` matrix-builds `.deb` and `.rpm` for `x86_64` and `aarch64` (the latter via QEMU on `ubuntu-latest`), then uploads all six artifacts to the GitHub Release via `softprops/action-gh-release@v2`.
+- **Frozen-binary data-files fix.** The PyInstaller specs for both the Windows and Linux pipelines now call `collect_data_files(pkg, include_py_files=False)` per package, so `pythinker_code/prompts/*.md`, `agents/default/*.yaml`, `tools/*/description.md`, `skills/*/SKILL.md`, and similar package resources are bundled into `_internal/`. Without this fix the frozen binary crashed the first time it tried to load `init.md` or an agent yaml. The Windows installer that shipped in 0.12.0 is affected; users on that build should upgrade to 0.13.0.
+- **Legacy install paths deprecated.** `scripts/install.sh`, `scripts/install.ps1`, `uvx pythinker-code`, `uv tool install pythinker-code`, `pipx install pythinker-code`, and bare `pip install pythinker-code` continue to work for existing automation. The two helper scripts now print a `[DEPRECATED]` banner at startup, pause 3 s, and point at the OS-specific native installer; set `PYTHINKER_INSTALL_QUIET_DEPRECATION=1` to suppress the banner. README Quick Start now leads with the per-OS install table.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.13.0`, or use the native installer for your OS (see the README install table).
+
+## 0.12.0 (2026-05-22)
+
+### What changed in this release
+
+- **Native Windows installer.** A signed `PythinkerSetup-x.y.z.exe` is now attached to every GitHub Release — install Pythinker on Windows with one download, no Python / Node / uv prerequisite. The wizard installs per-user (no UAC) into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on the user PATH, and broadcasts `WM_SETTINGCHANGE` so new shells pick the change up immediately. Uninstall reverses the PATH edit. Code-signing is wired through `signtool` and ships unsigned until the Authenticode cert lands; from that point forward the same CI job produces signed installers with no code change required.
+- **In-app updates for the native build.** `pythinker update` from a native install detects the build (via a `.pythinker-native` sentinel next to `pythinker.exe`), fetches the latest GitHub Release asset, verifies its SHA-256, and re-runs the installer silently (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`). The `PYTHINKER_CLI_NO_AUTO_UPDATE` opt-out env var that the PyPI path already honors now also gates the native auto-update path — one knob, both flows. The update banner shows a human-readable `PythinkerSetup-x.y.z.exe` line instead of leaking internal markers.
+- **Tag-triggered Windows build pipeline.** A new `.github/workflows/windows-installer.yml` runs on every `pythinker-code-v*` tag, freezes `pythinker` via PyInstaller (`--onedir` for faster startup and fewer AV false positives), compiles the Inno Setup script, signs the result if `WINDOWS_CERT_PFX_BASE64` / `WINDOWS_CERT_PASSWORD` secrets are populated, and uploads the `.exe` plus its `.sha256` to the corresponding Release.
+- **Shell terminal rhythm refinements.** Tone tokens, motion timing, and theme palette were retuned (sky-blue `#7dd3fc` / `#93c5fd` accents) so transcript rows, motion status, and dialog surfaces breathe consistently. UI snapshot tests updated to lock the new rhythm in place.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.12.0`, or — on Windows — download `PythinkerSetup-0.12.0.exe` from the Releases page.
+
+## 0.11.0 (2026-05-22)
+
+### What changed in this release
+
+- **Fixed PyPI install conflict (was failing on Windows and every other platform).** `pip install pythinker-code==0.10.0` failed with `fastmcp 3.2.0 depends on mcp<2.0 and >=1.24.0` vs `pythinker-core 1.1.0 depends on mcp<1.17 and >=1`. 0.11.0 pins the republished `pythinker-core 1.1.1`, whose widened `mcp>=1.23,<2` constraint lets the resolver pick a single `mcp` version compatible with `fastmcp==3.2.0`.
+- **Blackbox-style TUI port — phase 1.** Shell design primitives, compact transcript activity rows, blackbox-style motion status, standardized shell dialogs, aligned footer status styling, and a restyled tool-result surface land together. The TUI now shares a coherent visual language across rows, dialogs, and motion.
+- **Refreshed TUI accent palette.** Dark/light theme accent retuned to a cleaner sky-blue (`#7dd3fc` dark, `#0284c7` light) for better contrast against the new tool-result surfaces.
+- **Markdown + report polish.** Report spacing and markdown code blocks render with improved breathing room and consistent fences.
+- **Rotating thinking-word indicator restored** with a leading space before the live stream status so the spinner no longer abuts surrounding text.
+- **Internal audit + smoke evaluation.** A blackbox TUI scope map, prompt/agent audit, and a recorded visual smoke evaluation join the repo to govern future TUI work.
+
+Upgrade with `pythinker update` or `pip install --upgrade pythinker-code==0.11.0`.
+
+## 0.10.0 (2026-05-22)
+
+### What changed in this release
+
+- **Tool failure recovery improvements.** The agent loop now handles malformed or empty tool-call responses more gracefully and can continue the session instead of leaving the UI stuck after a bad provider turn.
+- **Safer file edits.** File write and replace tools now create restore points before mutating files, giving sessions a clearer recovery path after risky changes.
+- **Session UX state tracking.** Runtime session state now records additional UX metadata so shell surfaces can provide better continuity across long-running work.
+- **Shell command enhancements.** New shell slash-command plumbing improves discoverability and keeps interactive workflows smoother.
+- **TUI renderer polish.** Tool cards now share more consistent status glyphs, truncation behavior, and result summaries across bash, read, write, edit, grep, find, web, subagent, background, ask-user, and think renderers.
+- **Clipboard handling hardening.** Clipboard helpers now degrade more cleanly when platform clipboard access is unavailable.
+- **Release and TUI specs.** The repository now includes the blackbox TUI port design and a visual smoke-test criterion for future terminal UI work.
+
+Upgrade with `pythinker update` or `pip install --upgrade pythinker-code==0.10.0`.
+
+## 0.9.0 (2026-05-21)
+
+### What changed in this release
+
+- **Cleaner TUI — tool card backgrounds removed.** The grey pending/running
+  background overlay that appeared behind every tool execution card (subagents,
+  bash executions, reads, etc.) has been removed. Only user-message blocks
+  retain a background tint, keeping the visual hierarchy focused on your input.
+- **Welcome screen enhancements.** The startup info panel now shows the current
+  git branch (when inside a git repo) and the session auto-save path alongside
+  the working directory and session ID. Branch name is highlighted in magenta
+  for quick scanning.
+- **Bash header strip styling.** The `$ command` portion of bash execution
+  headers now picks up the `tool_pending_bg` token for the strip background,
+  matching the reference renderer style and providing consistent visual weight
+  across themes.
+- **Pythinker markdown renderer wired into message components.** User messages,
+  assistant messages, and custom messages now render through `pythinker_markdown`
+  (the project's own Markdown renderer) instead of raw `rich.markdown.Markdown`,
+  giving consistent heading, code-block, and table styling everywhere.
+- **Expanded theme palette.** `theme.py` gains a full `MarkdownColors` /
+  `markdown_rich_style` subsystem with dark and light palettes covering headings,
+  emphasis, inline code, links, blockquotes, table borders, code-block borders
+  and backgrounds, and spinner states (active/done/failed).
+- **Improved tool fallback renderers.** The call fallback now emits a
+  status-glyph header (`✔`/`✘`/`●`) instead of a bare label. The result
+  fallback now truncates long outputs at 60 lines / 4000 chars with an
+  italicised note (matching the card renderer's behaviour), and applies the
+  correct theme tokens for error vs. muted output.
+
+Upgrade with `pythinker update` or `pip install --upgrade pythinker-code==0.9.0`.
 
 ## 0.8.0 (2026-05-21)
 

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.24.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.25.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/packages/homebrew-tap/generate-formula.py
+++ b/packages/homebrew-tap/generate-formula.py
@@ -7,7 +7,7 @@ resources.
 
 Usage:
     python generate-formula.py \
-        --version 0.24.0 \
+        --version 0.25.0 \
         --template packages/homebrew-tap/pythinker-code.rb.tmpl \
         --output Formula/pythinker-code.rb
 """

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code_0.24.0_amd64.deb
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code_0.24.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.24.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.24.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code_0.25.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code_0.25.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.25.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.25.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.24.0/pythinker-code-0.24.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.24.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.24.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.25.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.25.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.24.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.25.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.24.0
+bash packages/linux-installer/build.sh 0.25.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.24.0_amd64.deb`
-- `pythinker-code-0.24.0.x86_64.rpm`
+- `pythinker-code_0.25.0_amd64.deb`
+- `pythinker-code-0.25.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.24.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.25.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.24.0"
+version = "0.25.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/install-native.sh
+++ b/scripts/install-native.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.24.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.25.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2402,7 +2402,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },

--- a/web/public/install.ps1
+++ b/web/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.24.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.25.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.24.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker


### PR DESCRIPTION
Prepare the **pythinker-code 0.25.0** release.

## What changed in this release

- **\`Fetch\` re-checks every redirect hop against the SSRF guard.** Redirects were followed without re-validating the destination, so a public URL could redirect to a link-local address (e.g. a cloud metadata endpoint) and slip past the guard. Every hop is now re-validated, closing the public→link-local bypass.
- **Crash-consistent background tasks.** Task state is serialised under a cross-process per-task lock, terminal agent-task updates route through a single finalizer, and recovery reconciles records left divergent by a crash or kill without clobbering a live agent. Bash output is capped (default 50 MiB), kills escalate SIGTERM→SIGKILL, and aged terminal tasks are pruned (default 7 days).
- **Calmer, more reliable TUI.** No double todo render mid-turn, detached OAuth/feedback link launch, and terminal restore on \`SIGTERM\`/\`SIGQUIT\` and at exit.
- **Steadier agent loop.** Bare-intent end-of-turn nudge, steering away from blocking on one background task while siblings run, and transparent parsing of JSON-string \`SetTodoList\` payloads.
- **Unified report rendering.** Code review, verify, and security-review output share one standardized renderer, including \`report\` blocks from skills and agents.

## Release mechanics

- Version bumped \`0.24.0\` → \`0.25.0\` across the standard 18-file scope (pyproject, uv.lock pythinker-code block, README, docs, install scripts, homebrew/linux/windows packaging).
- CHANGELOG / docs changelog / breaking-changes updated for 0.25.0.
- Local release gates pass: version-tag check, README/CHANGELOG greps, dependency-version check, installation-docs + homebrew-formula tests.

Tagging \`v0.25.0\` after merge triggers \`release-pythinker-cli.yml\` (PyPI + TestPyPI + GitHub Release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped project version to 0.25.0 across configuration, install scripts, and CI workflow dispatch examples

* **Documentation**
  * Added 0.25.0 release notes describing redirect handling, background-task finalization, TUI reliability, agent-loop steadiness, live tool feedback, and unified report rendering
  * Confirmed no breaking changes vs 0.24.0 and updated install/upgrade instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TechMatrix-labs/pythinker-code/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->