### PR TITLE
fix(homebrew): show logo in brew install, guard empty tap token

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -76,6 +76,10 @@ jobs:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euxo pipefail
+          if [ -z "${TAP_TOKEN:-}" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN secret is empty or unset — cannot push to ${TAP_OWNER}/${TAP_REPO}. Add a fine-grained PAT (Contents: Read and write on the tap repo) as the HOMEBREW_TAP_TOKEN secret, then re-run this workflow." >&2
+            exit 1
+          fi
           # We do NOT use actions/checkout for the tap repo because on the
           # very first run the tap is empty and has no refs/heads/main yet.
           # `git init` + `git fetch || true` + `git push -u origin main`

--- a/packages/homebrew-tap/pythinker-code.rb.tmpl
+++ b/packages/homebrew-tap/pythinker-code.rb.tmpl
@@ -41,6 +41,23 @@ class PythinkerCode < Formula
     bin.write_exec_script libexec/"pythinker"
   end
 
+  def caveats
+    # Static settled frame of the curl/PowerShell installers' "Tetris" logo
+    # (install.sh / install.ps1). Homebrew renders caveats as plain text, so
+    # this is the uncoloured robot-head. The squiggly heredoc strips the common
+    # leading indent, so the art sits one column left of the curl banner.
+    <<~EOS
+
+            ●
+            │
+        ▛▀▀▀▀▀▀▀▜
+       ◖█ ◉   ◉ █◗
+        ▙▄▄▄≡▄▄▄▟
+
+        pythinker code · your next CLI agent
+    EOS
+  end
+
   test do
     assert_path_exists libexec/".pythinker-native"
     assert_match version.to_s, shell_output("#{bin}/pythinker --version")

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -20,16 +20,22 @@ def load_generator() -> ModuleType:
     return module
 
 
-def test_native_homebrew_formula_renders_release_tarballs() -> None:
-    generator = load_generator()
-    version = "1.2.3"
-    assets = {}
+def _fake_assets(generator: ModuleType, version: str) -> dict[str, dict[str, str]]:
+    """Build a fake GitHub release-asset map covering every native target."""
+    assets: dict[str, dict[str, str]] = {}
     for target in generator.NATIVE_TARGETS:
         name = target.asset_name(version)
         assets[name] = {
             "browser_download_url": f"https://example.invalid/{name}",
             "digest": "sha256:" + ("a" * 64),
         }
+    return assets
+
+
+def test_native_homebrew_formula_renders_release_tarballs() -> None:
+    generator = load_generator()
+    version = "1.2.3"
+    assets = _fake_assets(generator, version)
 
     formula = generator.render_formula(
         TEMPLATE.read_text(encoding="utf-8"), generator.native_replacements(version, assets)
@@ -64,13 +70,7 @@ def test_native_homebrew_formula_fails_when_asset_missing() -> None:
 def test_native_homebrew_formula_caveats_show_logo() -> None:
     generator = load_generator()
     version = "1.2.3"
-    assets = {}
-    for target in generator.NATIVE_TARGETS:
-        name = target.asset_name(version)
-        assets[name] = {
-            "browser_download_url": f"https://example.invalid/{name}",
-            "digest": "sha256:" + ("a" * 64),
-        }
+    assets = _fake_assets(generator, version)
 
     formula = generator.render_formula(
         TEMPLATE.read_text(encoding="utf-8"), generator.native_replacements(version, assets)

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -59,3 +59,26 @@ def test_native_homebrew_formula_fails_when_asset_missing() -> None:
         assert "release asset missing" in str(exc)
     else:
         raise AssertionError("expected missing native asset to fail formula generation")
+
+
+def test_native_homebrew_formula_caveats_show_logo() -> None:
+    generator = load_generator()
+    version = "1.2.3"
+    assets = {}
+    for target in generator.NATIVE_TARGETS:
+        name = target.asset_name(version)
+        assets[name] = {
+            "browser_download_url": f"https://example.invalid/{name}",
+            "digest": "sha256:" + ("a" * 64),
+        }
+
+    formula = generator.render_formula(
+        TEMPLATE.read_text(encoding="utf-8"), generator.native_replacements(version, assets)
+    )
+
+    # Homebrew prints `caveats` after install — this is where the static robot
+    # logo (parity with install.sh / install.ps1) must live.
+    assert "def caveats" in formula
+    assert "pythinker code · your next CLI agent" in formula
+    # The robot-head mouth row is the most distinctive line of the art.
+    assert "▙▄▄▄≡▄▄▄▟" in formula


### PR DESCRIPTION
## Problem

Two issues with the Homebrew install path, surfaced from a real `brew install`:

1. **No logo on `brew install`.** The animated/static "Tetris" robot-head banner exists only in the curl installer (`install.sh`) and PowerShell installer (`install.ps1`). Homebrew runs the *formula*, not those scripts, and the formula had no `caveats`, so brew printed nothing.

2. **`brew install` served 0.23.0, not the current 0.25.0.** The **Update Homebrew tap** workflow has failed on every release since the org migration (0.24.0, 0.25.0). The failing step is `git push` to the tap repo:

   ```
   TAP_TOKEN:                       <- empty
   remote: Invalid username or token. Password authentication is not supported for Git operations.
   fatal: Authentication failed for '.../TechMatrix-labs/homebrew-pythinker.git/'
   exit code 128
   ```

   The `HOMEBREW_TAP_TOKEN` secret did **not** survive the `mohamed-elkholy95 → TechMatrix-labs` org migration (same class of breakage as the pythinker-home site-sync freeze). Formula *generation* succeeds; only the cross-repo *push* fails, so the tap stayed frozen at the last good push (0.23.0, with stale old-org asset URLs).

## Changes

- **`packages/homebrew-tap/pythinker-code.rb.tmpl`** — add a `caveats` block rendering the static settled frame of the robot-head logo + tagline (parity with `install.sh` / `install.ps1`; brew caveats are plain text, so no animation/colour).
- **`.github/workflows/homebrew-tap.yml`** — fail fast with an actionable message when `TAP_TOKEN` is empty/unset, instead of the opaque git exit-128.
- **`tests/test_homebrew_formula.py`** — assert the rendered formula carries the logo caveats (tagline + distinctive mouth row).

## Out of scope / follow-up

- **The `HOMEBREW_TAP_TOKEN` secret must be re-added** (fine-grained PAT, `Contents: Read and write` on `TechMatrix-labs/homebrew-pythinker`). This PR only makes the failure obvious and ships the logo — it does not restore the secret. Until then, every release's tap update will fail the guard with a clear error.
- The tap repo was **hand-republished to 0.25.0** out-of-band (new-org onedir URLs + caveats) so `brew install` works now; this PR makes future auto-updates correct once the token is restored.

## Verification

```
$ .venv/bin/python -m pytest tests/test_homebrew_formula.py
3 passed

$ python packages/homebrew-tap/generate-formula.py --version 0.25.0 \
    --template packages/homebrew-tap/pythinker-code.rb.tmpl --output /tmp/f.rb
# version 0.25.0, 4 onedir URLs (TechMatrix-labs), 4 sha256, caveats present, 0 unresolved placeholders
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homebrew installation now shows an ASCII-art logo and a branded welcome/caveat message after install.

* **Chores**
  * Deployment workflow now validates the Homebrew tap authentication token before attempting to publish, preventing failed pushes.

* **Tests**
  * Added tests to verify the formula displays the caveats/logo and to improve Homebrew formula asset handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TechMatrix-labs/pythinker-code/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->