### PR TITLE
chore(release): prepare 0.26.0

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to push to the tap (e.g. 0.25.0)"
+        description: "Version to push to the tap (e.g. 0.26.0)"
         required: true
         type: string
 

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.25.0)"
+        description: "Version to build (e.g. 0.26.0)"
         required: true
         type: string
 

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to promote (e.g. v0.25.0)"
+        description: "Release tag to promote (e.g. v0.26.0)"
         required: true
         type: string
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.25.0)"
+        description: "Version to build (e.g. 0.26.0)"
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.26.0 (2026-05-30)
+
+### What changed in this release
+
+- **Install and update no longer 404 on a freshly published release.** The 0.24.0 "atomic latest" gate turned out to be dead code — it ran only on a `release: published` event that a token-created release never fires, and did not affect `/releases/latest` anyway. The GitHub Release is now created as a **prerelease**, and a new `promote-release.yml` runs on the tag push, waits for every platform asset to finish uploading, then clears the prerelease flag and marks the release latest — the single point at which a version becomes resolvable by installers and the in-app updater. As defense-in-depth, the curl and PowerShell installers now resolve the newest release that actually carries their platform asset (skipping drafts and prereleases) and wait for the archive plus checksum before downloading, so `irm | iex` / `curl | bash` run during the publish window no longer fail on a missing `PythinkerSetup-<ver>.exe` or archive.
+- **OpenCode Go model catalog refreshes on every startup without a re-login.** Bundled catalog changes — new models, corrected provider shapes — previously reached an existing install only after a manual `pythinker login --opencode-go`. OpenCode Go is now wired into the every-startup `refresh_managed_models` task with its own discovery and a dedicated apply that upserts and prunes across both its OpenAI- and Anthropic-shaped providers while preserving your `default_model` and `default_thinking`. Discovery failures are isolated so they cannot abort other providers' saves; provider `base_url` repairs still require a re-login.
+- **Homebrew install shows the logo and fails fast on a missing tap token.** `brew install` now prints the robot-head banner via a formula `caveats` block — the banner previously lived only in the curl and PowerShell installers, which Homebrew never runs. The tap auto-update workflow now detects an empty `HOMEBREW_TAP_TOKEN` (lost in the org migration, which had frozen the tap at 0.23.0) and fails with an actionable error instead of an opaque git exit-128.
+- **Markdown and report rendering hardened against real model output.** Code-span pipes inside Markdown tables are now protected so a `|` inside backticks no longer fractures the table, and a `report` block nested inside an outer documentation fence is no longer wrongly promoted to a report — report fences are extracted via a markdown-it AST walk instead of a flat regex. Backed by a new TUI markdown/report contract test suite grounded in a real security-scan fixture.
+- **Steadier agent editing and a restored update prompt.** File-replace edit handling is hardened, subagent prompt persistence and the agent's working language are preserved across turns, and the todo list stays aligned during a turn. The blocking pre-start update prompt — wired in 0.24.0 but again left unwired by a later refactor — is restored so it runs before every interactive session.
+- **CI runs required checks on every pull request.** The `check`, `test`, and `release-validate` contexts were path-filtered off docs-only (and `sdks/`/`examples/`-only) PRs, so the required statuses never reported and those PRs stayed BLOCKED under branch protection with no clean override. The `pull_request` path filter is dropped so every PR runs each required context exactly once; the `push` trigger keeps its filter unchanged.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.26.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.25.0 (2026-05-29)
 
 ### What changed in this release

--- a/README.md
+++ b/README.md
@@ -50,16 +50,15 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.25.0
+## 🆕 What's New in 0.26.0
 
-- **`Fetch` re-checks every redirect hop against the SSRF guard.** Redirects were followed without re-validating the destination, so a public URL could redirect to a link-local address (e.g. a cloud metadata endpoint) and slip past the guard. Every hop is now re-validated, closing the public→link-local bypass.
-- **Web domain allowlist for `Fetch` and `Search`.** Set `web.allowed_domains` to restrict which hosts the web tools may reach — `Fetch` (every redirect hop included) and `Search` reject anything off the list. Leave it unset to keep web access unrestricted.
-- **Crash-consistent background tasks.** Task state is serialised under a cross-process lock, terminal updates route through a single finalizer, and recovery reconciles records left divergent by a crash or kill without clobbering a live agent. Bash output is capped (default 50 MiB), kills escalate SIGTERM→SIGKILL, and aged terminal tasks are pruned (default 7 days).
-- **Calmer TUI with live tool feedback.** Tool calls show a "preparing" row during approval, stream shell output as a running tail, and render a live Markdown preview as the model writes. The todo list no longer renders twice mid-turn, links open through a detached launcher, and the terminal is restored to a sane state on `SIGTERM`/`SIGQUIT` and at exit.
-- **Steadier agent loop.** The model is nudged when a turn ends on a bare statement of intent, steered away from blocking on one background task while siblings run, and a `SetTodoList` whose todos arrive as a JSON string is parsed transparently instead of failing validation.
-- **Unified report rendering.** Code review, verify, and security-review output share one standardized renderer, including `report` blocks emitted by skills and agents.
+- **Install and update no longer 404 on a freshly published release.** Releases are now published as a prerelease and promoted to "latest" only once every platform asset has uploaded, and the curl/PowerShell installers wait for their archive + checksum before downloading — so `irm | iex` / `curl | bash` run mid-publish no longer fail on a missing installer.
+- **OpenCode Go model catalog refreshes on startup without a re-login.** Bundled catalog changes (new models, corrected provider shapes) now reach existing installs through the every-startup refresh, across both OpenAI- and Anthropic-shaped providers, while preserving your default model and thinking settings.
+- **Homebrew install shows the logo and fails fast on a missing tap token.** `brew install` now prints the robot-head banner via formula caveats, and the tap workflow reports an actionable error when `HOMEBREW_TAP_TOKEN` is missing instead of an opaque git failure.
+- **Markdown and report rendering hardened against real model output.** Code-span pipes inside tables no longer fracture the table, and a `report` block nested inside a documentation fence is no longer wrongly promoted — report fences are now extracted via a markdown-it AST walk.
+- **Steadier agent editing and a restored update prompt.** File-replace edit handling is hardened, subagent prompt persistence and the agent's working language are preserved, and the blocking pre-start update prompt is restored so it runs before every interactive session.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.25.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.26.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -149,7 +148,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.25.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.26.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install TechMatrix-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **<img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux"> — system package** | Download the `.deb` or `.rpm` for your distro below | [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
@@ -174,7 +173,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.25.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.26.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -185,13 +184,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.25.0.exe
+.\PythinkerSetup-0.26.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.25.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.26.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -242,26 +241,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.25.0_amd64.deb
+sudo dpkg -i pythinker-code_0.26.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.25.0_arm64.deb
+sudo dpkg -i pythinker-code_0.26.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.25.0.x86_64.rpm.sha256
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.26.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.25.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.26.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.25.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.26.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.aarch64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.25.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.25.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.26.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.26.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -270,8 +269,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.25.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.25.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.26.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.26.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /
@@ -301,7 +300,7 @@ at `~/.local/bin/pythinker`.
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.25.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.26.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -2,6 +2,10 @@
 
 This page documents breaking changes in Pythinker Code releases and provides migration guidance.
 
+## 0.26.0 (2026-05-30)
+
+No breaking changes. This release is compatible with 0.25.0 user configuration, native installs, and session data.
+
 ## 0.25.0 (2026-05-29)
 
 No breaking changes. This release is compatible with 0.24.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,19 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.26.0 (2026-05-30)
+
+### What changed in this release
+
+- **Install and update no longer 404 on a freshly published release.** The 0.24.0 "atomic latest" gate turned out to be dead code — it ran only on a `release: published` event that a token-created release never fires, and did not affect `/releases/latest` anyway. The GitHub Release is now created as a **prerelease**, and a new `promote-release.yml` runs on the tag push, waits for every platform asset to finish uploading, then clears the prerelease flag and marks the release latest — the single point at which a version becomes resolvable by installers and the in-app updater. As defense-in-depth, the curl and PowerShell installers now resolve the newest release that actually carries their platform asset (skipping drafts and prereleases) and wait for the archive plus checksum before downloading, so `irm | iex` / `curl | bash` run during the publish window no longer fail on a missing `PythinkerSetup-<ver>.exe` or archive.
+- **OpenCode Go model catalog refreshes on every startup without a re-login.** Bundled catalog changes — new models, corrected provider shapes — previously reached an existing install only after a manual `pythinker login --opencode-go`. OpenCode Go is now wired into the every-startup `refresh_managed_models` task with its own discovery and a dedicated apply that upserts and prunes across both its OpenAI- and Anthropic-shaped providers while preserving your `default_model` and `default_thinking`. Discovery failures are isolated so they cannot abort other providers' saves; provider `base_url` repairs still require a re-login.
+- **Homebrew install shows the logo and fails fast on a missing tap token.** `brew install` now prints the robot-head banner via a formula `caveats` block — the banner previously lived only in the curl and PowerShell installers, which Homebrew never runs. The tap auto-update workflow now detects an empty `HOMEBREW_TAP_TOKEN` (lost in the org migration, which had frozen the tap at 0.23.0) and fails with an actionable error instead of an opaque git exit-128.
+- **Markdown and report rendering hardened against real model output.** Code-span pipes inside Markdown tables are now protected so a `|` inside backticks no longer fractures the table, and a `report` block nested inside an outer documentation fence is no longer wrongly promoted to a report — report fences are extracted via a markdown-it AST walk instead of a flat regex. Backed by a new TUI markdown/report contract test suite grounded in a real security-scan fixture.
+- **Steadier agent editing and a restored update prompt.** File-replace edit handling is hardened, subagent prompt persistence and the agent's working language are preserved across turns, and the todo list stays aligned during a turn. The blocking pre-start update prompt — wired in 0.24.0 but again left unwired by a later refactor — is restored so it runs before every interactive session.
+- **CI runs required checks on every pull request.** The `check`, `test`, and `release-validate` contexts were path-filtered off docs-only (and `sdks/`/`examples/`-only) PRs, so the required statuses never reported and those PRs stayed BLOCKED under branch protection with no clean override. The `pull_request` path filter is dropped so every PR runs each required context exactly once; the `push` trigger keeps its filter unchanged.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.26.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.25.0 (2026-05-29)
 
 ### What changed in this release

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.25.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.26.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/packages/homebrew-tap/generate-formula.py
+++ b/packages/homebrew-tap/generate-formula.py
@@ -7,7 +7,7 @@ resources.
 
 Usage:
     python generate-formula.py \
-        --version 0.25.0 \
+        --version 0.26.0 \
         --template packages/homebrew-tap/pythinker-code.rb.tmpl \
         --output Formula/pythinker-code.rb
 """

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code_0.25.0_amd64.deb
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code_0.25.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.25.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.25.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code_0.26.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code_0.26.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.26.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.26.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.25.0/pythinker-code-0.25.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.25.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.25.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.26.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.26.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.25.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.26.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.25.0
+bash packages/linux-installer/build.sh 0.26.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.25.0_amd64.deb`
-- `pythinker-code-0.25.0.x86_64.rpm`
+- `pythinker-code_0.26.0_amd64.deb`
+- `pythinker-code-0.26.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.25.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.26.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.25.0"
+version = "0.26.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/install-native.sh
+++ b/scripts/install-native.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.25.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.26.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2402,7 +2402,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },

--- a/web/public/install.ps1
+++ b/web/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.25.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.26.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.25.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker


### PR DESCRIPTION
Prepare pythinker-code **0.26.0** release.

## What changed in this release

- **Install and update no longer 404 on a freshly published release.** Releases are published as a prerelease and promoted to "latest" only after every platform asset uploads (new `promote-release.yml`); the curl/PowerShell installers wait for their archive + checksum before downloading. (#18)
- **OpenCode Go model catalog refreshes on every startup without a re-login.** Wired into the every-startup `refresh_managed_models` task across both OpenAI- and Anthropic-shaped providers, preserving `default_model`/`default_thinking`. (#21)
- **Homebrew install shows the logo and fails fast on a missing tap token.** Formula `caveats` banner; actionable error when `HOMEBREW_TAP_TOKEN` is empty. (#22)
- **Markdown and report rendering hardened against real model output.** Code-span pipes protected in tables; nested `report` fences no longer wrongly promoted (markdown-it AST extraction). (#23)
- **Steadier agent editing and a restored update prompt.** Hardened file-replace handling, preserved subagent prompt/language, restored blocking pre-start update prompt. (#23)
- **CI runs required checks on every pull request.** Dropped the `pull_request` path filter so `check`/`test`/`release-validate` report on every PR. (#17)

## Release mechanics

Mechanical `0.25.0` → `0.26.0` bump across pyproject, `uv.lock` (pythinker-code block only), install scripts, installer workflows, Homebrew formula generator, README/getting-started, and the linux-installer README. CHANGELOG `## Unreleased` consumed into a `## 0.26.0 (2026-05-30)` block (reconstructed from `v0.25.0..HEAD` since Unreleased was empty); docs changelog regenerated via the sync script; breaking-changes entry added (none).

Local gates pass: version-tag, README markers, CHANGELOG header, dependency-version, and `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` (17 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and guides for version 0.26.0 across all platforms.
  * Added release notes documenting bug fixes and improvements.
  * Confirmed backward compatibility; no breaking changes from the previous release.

* **Chores**
  * Bumped project version to 0.26.0.
  * Updated workflow and installation script examples with current version references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TechMatrix-labs/pythinker-code/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->