### PR TITLE
fix(ci): extend promote-release asset-wait budget to 40m

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -73,9 +73,19 @@ jobs:
             "aarch64-apple-darwin.tar.gz"
             "x86_64-apple-darwin.tar.gz"
           )
-          echo "Polling for all release assets on $TAG..."
+          # The budget must comfortably exceed the slowest platform build, since
+          # this job runs on the tag push in parallel with them. The long pole is
+          # linux-installer's emulated arm64 .deb/.rpm step: on the 0.26.0 release
+          # it finished at ~21m, 45s after the old 40x30s=20m budget had already
+          # timed out — leaving the release stuck as a prerelease. 80x30s=40m
+          # gives ~2x margin; a genuinely stuck build still surfaces as a failed
+          # build workflow, and workflow_dispatch allows a manual re-promote.
+          max_attempts=80
+          poll_interval=30
+          budget_min=$(( max_attempts * poll_interval / 60 ))
+          echo "Polling for all release assets on $TAG (up to ${budget_min}m)..."
           all_present=false
-          for i in $(seq 1 40); do
+          for i in $(seq 1 "$max_attempts"); do
             assets=$(gh api "repos/$REPO/releases/tags/$TAG" --jq '[.assets[].name] | join(" ")' 2>/dev/null || echo "")
             all_present=true
             for p in "${required[@]}"; do
@@ -88,11 +98,11 @@ jobs:
               echo "All assets present (attempt $i)"
               break
             fi
-            echo "Attempt $i/40: assets not ready, retrying in 30s..."
-            sleep 30
+            echo "Attempt $i/$max_attempts: assets not ready, retrying in ${poll_interval}s..."
+            sleep "$poll_interval"
           done
           if [[ "$all_present" != "true" ]]; then
-            echo "::error::Release assets not fully uploaded after 20 minutes"
+            echo "::error::Release assets not fully uploaded after ${budget_min} minutes"
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

The `promote-release` workflow runs on the tag push, **in parallel** with the platform build workflows, and polls for all release assets before clearing the prerelease flag and marking the release latest. The asset-wait budget was `40 × 30s = 20 minutes`.

On the **0.26.0 release** (the first real exercise of this flow, shipped in #24) the `linux-installer` workflow — whose long pole is the emulated arm64 `.deb`/`.rpm` build — did not finish attaching its assets until **~21 minutes** after the tag push, **45 seconds after** the poll budget had already expired:

| workflow | finished | promote budget |
|---|---|---|
| windows-installer | 08:40 | polled 08:36→08:56 |
| release-cli | 08:50 | (timed out) |
| **linux-installer** | **08:57** | ❌ exceeded |

The `promote` job failed, leaving v0.26.0 stuck as a **prerelease**, so `/releases/latest` kept resolving to v0.25.0 until a manual `workflow_dispatch` re-promote. (0.26.0 has since been promoted manually; this prevents recurrence.)

This was **not** a pattern-matching bug — all 9 required asset substrings were present once builds finished; the budget was simply shorter than the slowest build.

## Fix

Extend the budget to `80 × 30s = 40 minutes` (~2× margin over the observed long-pole build) and surface the attempt count / budget from named variables (`max_attempts`, `poll_interval`) instead of hardcoded literals.

A genuinely stuck or failed build still surfaces as its own failed build workflow, and the `workflow_dispatch` re-promote path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow reliability with improved polling configuration and logging for asset deployment monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TechMatrix-labs/pythinker-code/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->