### PR TITLE
fix(ci): authenticate tap push via org GitHub App, not a personal PAT

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -70,14 +70,29 @@ jobs:
           echo "--- generated formula head ---"
           head -40 out/Formula/pythinker-code.rb
 
+      # Mint a short-lived installation token for an org-owned GitHub App that
+      # has Contents: Read and write on the tap repo. This replaces a personal
+      # PAT: the App is owned by the org (survives member/org changes), its token
+      # expires in ~1h (minted fresh each run), and it is scoped to only the tap
+      # repo. owner/repositories are required because the App must reach a repo
+      # other than the one this workflow runs in.
+      - name: Mint GitHub App token for the tap repo
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: ${{ env.TAP_OWNER }}
+          repositories: ${{ env.TAP_REPO }}
+
       - name: Sync formula into tap repo (handles empty repo on first run)
         env:
           PKG_VERSION: ${{ steps.ver.outputs.version }}
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euxo pipefail
           if [ -z "${TAP_TOKEN:-}" ]; then
-            echo "::error::HOMEBREW_TAP_TOKEN secret is empty or unset — cannot push to ${TAP_OWNER}/${TAP_REPO}. Add a fine-grained PAT (Contents: Read and write on the tap repo) as the HOMEBREW_TAP_TOKEN secret, then re-run this workflow." >&2
+            echo "::error::No tap token available — the GitHub App token mint produced an empty value. Confirm the HOMEBREW_TAP_APP_ID and HOMEBREW_TAP_APP_PRIVATE_KEY secrets are set and the App is installed on ${TAP_OWNER}/${TAP_REPO} with Contents: Read and write, then re-run this workflow." >&2
             exit 1
           fi
           # We do NOT use actions/checkout for the tap repo because on the

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -78,7 +78,7 @@ jobs:
       # other than the one this workflow runs in.
       - name: Mint GitHub App token for the tap repo
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

`homebrew-tap.yml` pushes the generated formula to the **separate** `TechMatrix-labs/homebrew-pythinker` repo, which the default `GITHUB_TOKEN` can't write to — so it used a personal PAT in `HOMEBREW_TAP_TOKEN`. That PAT broke on the org migration and again on re-issue: it authenticated as `mohamed-elkholy95` but lacked `Contents: write`, so every `git push` 403'd and the tap froze at **0.25.0** (current latest release is 0.26.0).

## Fix

Mint a short-lived installation token at runtime from an **org-owned GitHub App** (`actions/create-github-app-token@v2`) scoped to the tap repo with `Contents: Read and write`:

- **Org-owned** → survives member/org-migration changes (the exact failure class that's bitten us twice).
- **Short-lived** → token expires in ~1h, minted fresh each run; nothing long-lived in CI except the App private key.
- **Repo-scoped** → `owner`/`repositories` limit the token to only `homebrew-pythinker`.

Deploy keys (the simpler robust option) are **disabled org-wide** for `TechMatrix-labs`, so the App is the frictionless path that needs no org-policy change. The HTTPS `x-access-token:<token>@github.com/...` push is unchanged — only the token source moved.

## Required secrets (set on `TechMatrix-labs/pythinker-code`)

| Secret | Value |
|---|---|
| `HOMEBREW_TAP_APP_ID` | the GitHub App's App ID |
| `HOMEBREW_TAP_APP_PRIVATE_KEY` | the App's generated `.pem` private key |

The old `HOMEBREW_TAP_TOKEN` secret is no longer referenced and can be deleted after this lands.

## Verification

After the App is created/installed and the secrets are set: re-run `homebrew-tap.yml` for 0.26.0 and confirm the tap formula flips to 0.26.0. (Tracked separately; this PR is the workflow wiring only.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved security for Homebrew repository sync by switching from long-lived static credentials to short-lived installation tokens.
  * Updated deployment messaging to provide clearer guidance for verifying app secrets, configuration, and installation permissions when authentication fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->