### PR TITLE
chore(release): prepare 0.27.0

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to push to the tap (e.g. 0.26.0)"
+        description: "Version to push to the tap (e.g. 0.27.0)"
         required: true
         type: string
 

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.26.0)"
+        description: "Version to build (e.g. 0.27.0)"
         required: true
         type: string
 

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to promote (e.g. v0.26.0)"
+        description: "Release tag to promote (e.g. v0.27.0)"
         required: true
         type: string
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.26.0)"
+        description: "Version to build (e.g. 0.27.0)"
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.27.0 (2026-05-31)
+
+### What changed in this release
+
 - **`/feedback` submits structured reports with redacted session context.** A new
   `/feedback [bug|feature|ux|wrong] [message]` command collects recent session context
   and strips sensitive file contents before sending, shows a confirmation preview, and
@@ -38,6 +42,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
   errors when `old` matches more than once instead of silently editing the first match. Add
   surrounding context to make the old string unique, or pass `replace_all=true` when every
   occurrence should change.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.27.0`, or use the native installer for your OS (see the README install table).
 
 ## 0.26.0 (2026-05-30)
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.26.0
+## 🆕 What's New in 0.27.0
 
-- **Install and update no longer 404 on a freshly published release.** Releases are now published as a prerelease and promoted to "latest" only once every platform asset has uploaded, and the curl/PowerShell installers wait for their archive + checksum before downloading — so `irm | iex` / `curl | bash` run mid-publish no longer fail on a missing installer.
-- **OpenCode Go model catalog refreshes on startup without a re-login.** Bundled catalog changes (new models, corrected provider shapes) now reach existing installs through the every-startup refresh, across both OpenAI- and Anthropic-shaped providers, while preserving your default model and thinking settings.
-- **Homebrew install shows the logo and fails fast on a missing tap token.** `brew install` now prints the robot-head banner via formula caveats, and the tap workflow reports an actionable error when `HOMEBREW_TAP_TOKEN` is missing instead of an opaque git failure.
-- **Markdown and report rendering hardened against real model output.** Code-span pipes inside tables no longer fracture the table, and a `report` block nested inside a documentation fence is no longer wrongly promoted — report fences are now extracted via a markdown-it AST walk.
-- **Steadier agent editing and a restored update prompt.** File-replace edit handling is hardened, subagent prompt persistence and the agent's working language are preserved, and the blocking pre-start update prompt is restored so it runs before every interactive session.
+- **`/feedback` submits structured reports with redacted session context.** A new `/feedback [bug|feature|ux|wrong] [message]` command collects recent session context, strips sensitive file contents before sending, shows a confirmation preview, and falls back to a prefilled GitHub issue when direct submission is unavailable.
+- **Fresh releases surface in the startup update prompt immediately.** The pre-start update prompt revalidates a cached "already current" answer with a bounded conditional request instead of waiting for the 24-hour throttle, and release promotion now waits for the native assets, PyPI, and the Homebrew tap before marking a version latest — so clients never resolve a release before its install channel is ready.
+- **Background agent recovery preserves terminal task state.** Recovery re-reads task runtime under the store update lock before marking orphaned agent work recoverable, so a stale snapshot can no longer clobber a task that already completed.
+- **Shell prompt echoes and background todo rows are clearer.** Transcript echoes now show the resolved submitted text for pasted-content placeholders, and background todo rows align continuation icons with the first row.
+- **StrReplaceFile refuses ambiguous single replacements.** A non-`replace_all` edit now errors when `old` matches more than once instead of silently editing the first match — add surrounding context to make it unique, or pass `replace_all=true` when every occurrence should change.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.26.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.27.0`, or use the native installer for your platform from the [Releases page](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -148,7 +148,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.26.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.27.0.exe` from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install TechMatrix-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **<img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux"> — system package** | Download the `.deb` or `.rpm` for your distro below | [Releases](https://github.com/TechMatrix-labs/pythinker-code/releases/latest) |
@@ -173,7 +173,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.26.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.27.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -184,13 +184,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.26.0.exe
+.\PythinkerSetup-0.27.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.26.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.27.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -241,26 +241,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.26.0_amd64.deb
+sudo dpkg -i pythinker-code_0.27.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.26.0_arm64.deb
+sudo dpkg -i pythinker-code_0.27.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.26.0.x86_64.rpm.sha256
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code-0.27.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code-0.27.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.27.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.26.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.27.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.26.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.27.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.aarch64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.26.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.26.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code-0.27.0.aarch64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code-0.27.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.27.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.27.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -269,8 +269,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.26.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.26.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.27.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.27.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /
@@ -300,7 +300,7 @@ at `~/.local/bin/pythinker`.
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.27.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.27.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.26.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.27.0.exe` manually from the [latest release](https://github.com/TechMatrix-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -2,6 +2,10 @@
 
 This page documents breaking changes in Pythinker Code releases and provides migration guidance.
 
+## 0.27.0 (2026-05-31)
+
+No breaking changes. This release is compatible with 0.26.0 user configuration, native installs, and session data.
+
 ## 0.26.0 (2026-05-30)
 
 No breaking changes. This release is compatible with 0.25.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,36 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.27.0 (2026-05-31)
+
+### What changed in this release
+
+- **`/feedback` submits structured reports with redacted session context.** A new
+  `/feedback [bug|feature|ux|wrong] [message]` command collects recent session context
+  and strips sensitive file contents before sending, shows a confirmation preview, and
+  falls back to opening a prefilled GitHub issue when direct submission is unavailable.
+- **Fresh releases surface in the startup update prompt immediately.** The pre-start
+  update prompt now revalidates a cached "already current" answer with a bounded
+  conditional request instead of waiting for the 24-hour background-check throttle.
+  Release promotion also waits for exact native assets, PyPI, and the Homebrew tap
+  before marking a version latest, so installed clients no longer resolve a release
+  before its install channel is ready.
+- **Background agent recovery preserves terminal task state.** Recovery now re-reads
+  task runtime under the store update lock before marking orphaned agent work
+  recoverable, so a stale snapshot can no longer clobber a task that completed.
+- **Project memory recall keeps the simple lexical path.** The unused SQLite FTS
+  retriever seam and dead recall path argument are removed; collaborators now use
+  a public memory-store root accessor instead of reaching into private methods.
+- **Shell prompt echoes and background todo rows are clearer.** Transcript echoes now
+  show the resolved submitted text for pasted-content placeholders, and background
+  todo rows align continuation icons with the first row.
+- **StrReplaceFile now refuses ambiguous single replacements.** A non-`replace_all` edit now
+  errors when `old` matches more than once instead of silently editing the first match. Add
+  surrounding context to make the old string unique, or pass `replace_all=true` when every
+  occurrence should change.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.27.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.26.0 (2026-05-30)
 
 ### What changed in this release

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.26.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.27.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.27.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/packages/homebrew-tap/generate-formula.py
+++ b/packages/homebrew-tap/generate-formula.py
@@ -7,7 +7,7 @@ resources.
 
 Usage:
     python generate-formula.py \
-        --version 0.26.0 \
+        --version 0.27.0 \
         --template packages/homebrew-tap/pythinker-code.rb.tmpl \
         --output Formula/pythinker-code.rb
 """

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code_0.26.0_amd64.deb
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code_0.26.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.26.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.26.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code_0.27.0_amd64.deb
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code_0.27.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.27.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.27.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm
-curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.26.0/pythinker-code-0.26.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.26.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.26.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code-0.27.0.x86_64.rpm
+curl -LO https://github.com/TechMatrix-labs/pythinker-code/releases/download/v0.27.0/pythinker-code-0.27.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.27.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.27.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.26.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.27.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.26.0
+bash packages/linux-installer/build.sh 0.27.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.26.0_amd64.deb`
-- `pythinker-code-0.26.0.x86_64.rpm`
+- `pythinker-code_0.27.0_amd64.deb`
+- `pythinker-code-0.27.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.26.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.27.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.26.0"
+version = "0.27.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/install-native.sh
+++ b/scripts/install-native.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.27.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.26.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.27.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2402,7 +2402,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },

--- a/web/public/install.ps1
+++ b/web/public/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://pythinker.com/install.ps1 | iex
 #
 # To pin a version when running the hosted script, set:
-#   $env:PYTHINKER_VERSION = "0.26.0"; irm https://pythinker.com/install.ps1 | iex
+#   $env:PYTHINKER_VERSION = "0.27.0"; irm https://pythinker.com/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://pythinker.com/install.sh | bash
 #
 #   # Pin a specific version:
-#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.26.0
+#   curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.27.0
 #
 #   # Custom install prefix (default $HOME/.local):
 #   curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker


### PR DESCRIPTION
Prepares the 0.27.0 release: version bump across the standard release file set, plus CHANGELOG/README/docs narrative.

## What changed in this release

- **`/feedback` submits structured reports with redacted session context.** New `/feedback [bug|feature|ux|wrong] [message]` command (#31).
- **Fresh releases surface in the startup update prompt immediately.** Pre-start prompt revalidates cached "already current" with a bounded conditional request; promotion waits for native assets, PyPI, and the Homebrew tap before marking latest (#30).
- **Background agent recovery preserves terminal task state.** Recovery re-reads task runtime under the store update lock before marking orphaned work recoverable (#29).
- **Project memory recall keeps the simple lexical path.** Unused SQLite FTS retriever seam and dead recall path argument removed (#29).
- **Shell prompt echoes and background todo rows are clearer.** (#29)
- **StrReplaceFile refuses ambiguous single replacements.** Non-`replace_all` edit errors when `old` matches more than once (#29).

Dependency bump (#32) and CI-only changes (#25, #27, #28) are intentionally not in the user-facing notes, consistent with prior releases.

## Release mechanics

- Version bumped `0.26.0` → `0.27.0` across the standard ~18-file scaffold (pyproject, uv.lock, install scripts, workflow input examples, README/docs asset names).
- `## Unreleased` consumed into `## 0.27.0 (2026-05-31)`; mirrored into docs changelog; breaking-changes entry added (no breaking changes).
- Local gates pass: version-tag check, README markers, CHANGELOG header, pythinker dependency-version check, `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` (17 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured feedback submissions with improved context handling
  * Enhanced background agent recovery for terminal tasks
  * Improved release promotion and update prompt revalidation
  * Project memory and session path enhancements
  * Stricter file replacement validation

* **Documentation**
  * Updated installation guides and scripts for version 0.27.0
  * Added release notes and breaking changes documentation

* **Chores**
  * Version bump to 0.27.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->