### PR TITLE
docs: remove dead Zsh plugin integration

### DIFF
--- a/docs/en/guides/integrations.md
+++ b/docs/en/guides/integrations.md
@@ -1,36 +1,3 @@
 # Integrations with Tools
 
 Besides using in the terminal and IDEs, Pythinker Code can also be integrated with other tools.
-
-## Zsh plugin
-
-[zsh-pythinker-code](https://github.com/mohamed-elkholy95/zsh-pythinker-code) is a Zsh plugin that lets you quickly switch to Pythinker Code in Zsh.
-
-**Installation**
-
-If you use Oh My Zsh, you can install it like this:
-
-```sh
-git clone https://github.com/mohamed-elkholy95/zsh-pythinker-code.git \
-  ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/pythinker-code
-```
-
-Then add the plugin in `~/.zshrc`:
-
-```sh
-plugins=(... pythinker-code)
-```
-
-Reload the Zsh configuration:
-
-```sh
-source ~/.zshrc
-```
-
-**Usage**
-
-After installation, press `Ctrl-X` in Zsh to quickly switch to Pythinker Code without manually typing the `pythinker` command.
-
-::: tip
-If you use other Zsh plugin managers (like zinit, zplug, etc.), please refer to the [zsh-pythinker-code repository](https://github.com/mohamed-elkholy95/zsh-pythinker-code) README for installation instructions.
-:::


### PR DESCRIPTION
The `zsh-pythinker-code` repo 404s under both the current owner (`elkaix`) and the former handle (`mohamed-elkholy95`), so the Zsh-plugin section linked only to dead URLs. This removes the section; the page keeps its intro.

**Out of scope (intentionally left):** the other `mohamed-elkholy95` references in `feedback_repo.py` + its tests are the legacy *migrate-from* owner (rewritten to `Pythoughts-labs/pythinker-code`); renaming them would break feedback migration and its tests. The `superpowers/*` specs reference another repo's (pythinker-home) config and are doc-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integrations guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->