### PR TITLE
fix(ci): restore version-tag trigger glob in release workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker (GHCR)
 on:
   push:
     tags:
-      - "v+([0-9]).+([0-9]).+([0-9])"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -3,7 +3,7 @@ name: Update Homebrew tap
 on:
   push:
     tags:
-      - "v+([0-9]).+([0-9]).+([0-9])"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       # Same scheme as release-pythinker-cli.yml and windows-installer.yml.
-      - "v+([0-9]).+([0-9]).+([0-9])"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -16,7 +16,7 @@ name: Promote release
 on:
   push:
     tags:
-      - "v+([0-9]).+([0-9]).+([0-9])"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release-pythinker-cli.yml
+++ b/.github/workflows/release-pythinker-cli.yml
@@ -3,7 +3,7 @@ name: Release (pythinker-code)
 on:
   push:
     tags:
-      - "v+([0-9]).+([0-9]).+([0-9])"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write

--- a/.github/workflows/scoop-bucket.yml
+++ b/.github/workflows/scoop-bucket.yml
@@ -3,7 +3,7 @@ name: Update Scoop bucket
 on:
   push:
     tags:
-      - "v+([0-9]).+([0-9]).+([0-9])"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       # Match the existing PyPI release workflow's tag scheme: v<MAJOR>.<MINOR>.<PATCH>.
-      - "v+([0-9]).+([0-9]).+([0-9])"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Root cause

`fb7fdbf ci(actions): update workflows for Node 24` rewrote the `v*` tag trigger:

```diff
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v+([0-9]).+([0-9]).+([0-9])"
```

GitHub Actions ref filters are **not** ksh extglob — `(` and `)` are literal characters, so `v+([0-9]).+([0-9]).+([0-9])` only matches a tag containing literal parentheses. No real version tag matches, so the trigger silently fires nothing. `v0.28.0` was the first tag pushed after this change and triggered **zero** workflows (verified: pushed both lightweight and annotated tags, neither produced a run; GitHub status all-operational).

## Blast radius

The broken pattern was applied to all 7 `v*`-tag-triggered workflows: `release-pythinker-cli` (PyPI + GitHub release), `promote-release`, `linux-installer`, `windows-installer`, `homebrew-tap`, `scoop-bucket`, `docker`. The whole release pipeline was dead for tagged releases. (`release-pythinker-{core,host,sdk}` use `pythinker-*-*` globs and were unaffected.)

## Fix

Restore the proven `"v[0-9]+.[0-9]+.[0-9]+"` pattern — the exact one that shipped v0.24.0–v0.27.0 — across all 7 files. Five of them regressed from this pattern in `fb7fdbf`; `scoop-bucket` and `docker` are newer (added after v0.27.0) and were born with the broken pattern.

After this merges, `v0.28.0` is re-tagged onto the fixed commit (GitHub evaluates the tag trigger from the workflow file **at the tagged commit**, so the tag must point past this fix).

[skip changelog] — CI trigger fix, no user-facing product change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized version tag detection across all build and release workflows (Docker, Homebrew, Scoop, PyPI, Windows/Linux installers) to support semantic version tags (v1.2.3).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->