### PR TITLE
ci: add release concurrency guards + document release gotchas

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: homebrew-tap-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: linux-installer-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/release-pythinker-cli.yml
+++ b/.github/workflows/release-pythinker-cli.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+concurrency:
+  group: release-pythinker-cli-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: windows-installer-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,3 +422,26 @@ user or release workflow explicitly asks for that package.
    resolvable by the install scripts and the in-app updater. If a builder is
    re-run after promotion it flips the Release back to prerelease; recover by
    running `promote-release.yml` via `workflow_dispatch` for that tag.
+
+### Release pipeline gotchas
+
+Hard-won traps — re-check these before and during a release:
+
+- **Tag triggers use GitHub's glob filter, which is NOT regex or ksh extglob.** Every `v*`-triggered
+  workflow (`release-pythinker-cli`, `promote-release`, `linux-installer`, `windows-installer`,
+  `homebrew-tap`, `scoop-bucket`, `docker`) must filter on `"v[0-9]+.[0-9]+.[0-9]+"`. In a GitHub tag
+  filter `(` and `)` are literal characters, so an extglob-style pattern such as
+  `"v+([0-9]).+([0-9]).+([0-9])"` matches no real tag and silently fires **nothing** — the release looks
+  like it "did nothing" with no error anywhere. Do not "modernize" these patterns into extglob/regex.
+- **A pushed tag runs the workflow definition that exists AT the tagged commit.** If you fix a release
+  workflow or its trigger, re-create the tag on the post-fix commit — re-pushing a tag that still points
+  at the pre-fix commit just re-runs the broken definition. Use an annotated tag
+  (`git tag -a vX.Y.Z -m ...`). Pre-flight before re-tagging: confirm nothing shipped yet
+  (`gh release view vX.Y.Z` is "not found" and `https://pypi.org/pypi/pythinker-code/X.Y.Z/json` is 404),
+  then delete the old tag locally and on origin and re-push.
+- **`main` requires conversation resolution, so all-green checks are not sufficient to merge.** If
+  `gh pr view <n> --json mergeStateStatus` shows `BLOCKED` while every required check is `SUCCESS`, look
+  for an unresolved review thread — CodeRabbit can open one even when its commit status reads "Review
+  skipped". Inspect via the `reviewThreads` GraphQL field, verify the finding, reply in-thread, then
+  `resolveReviewThread`. `main` is also squash-only (linear history, `enforce_admins` on), so merge with
+  `gh pr merge --squash`.


### PR DESCRIPTION
Follow-up to #46 — hardens the release pipeline and records the traps hit while shipping 0.28.0.

## Concurrency guards

Adds a per-ref `concurrency` group to the four `v*`-tag publishers that lacked one — `release-pythinker-cli`, `linux-installer`, `windows-installer`, `homebrew-tap` — so the whole `v*` pipeline is consistently protected against overlapping **same-tag** runs (a double tag push or a re-run). `scoop-bucket`, `docker`, and `promote-release` already had it.

`cancel-in-progress: false` is deliberate: a publish/upload must never be cancelled mid-flight. Per-ref groups (`group: <workflow>-${{ github.ref }}`) mean different workflows still run concurrently as the prerelease→promote coordination expects — only the *same* workflow for the *same* tag serializes. Resolves the concurrency nit deferred from #46.

## Release pipeline gotchas (AGENTS.md)

New "Release pipeline gotchas" section documenting what cost us a few cycles on 0.28.0:

1. **Tag triggers are GitHub glob, not regex/extglob** — `(` `)` are literal, so `"v+([0-9]).+([0-9]).+([0-9])"` (introduced in `fb7fdbf`) matched no tag and silently fired nothing. Must be `"v[0-9]+.[0-9]+.[0-9]+"`.
2. **A pushed tag runs the workflow at the tagged commit** — fix a release workflow, then re-tag onto the post-fix commit (annotated; pre-flight that nothing shipped before deleting/re-pushing).
3. **`main` requires conversation resolution** — `mergeStateStatus: BLOCKED` with all checks green = an unresolved review thread (CodeRabbit opens them even when its status says "Review skipped"); resolve to unblock. `main` is squash-only.

## Validation

- All 7 `v*`-path workflows parse as valid YAML and now carry a `concurrency` block.
- `pytest tests/core/test_load_agents_md.py tests/core/test_default_agent.py` → 17 passed (AGENTS.md edit doesn't affect prompt loading).

[skip changelog] — CI/docs hardening, no user-facing product change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured concurrency controls across CI/CD workflows (Homebrew, Linux, Windows, and release pipelines) to serialize builds and prevent duplicate executions.

* **Documentation**
  * Added release pipeline operational guidelines covering trigger patterns, workflow configuration alignment, and branch merge procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->