### PR TITLE
chore(release): prepare 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,16 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.29.0 (2026-06-01)
+
+### What changed in this release
+
 - **Reloads pick up MCP and model changes cleanly.** `/reload` now re-reads MCP server configuration added after startup, cleans up stale MCP/model-refresh resources during same-process reloads, and `/model` starts a fresh session when switching models so old context does not carry across providers.
 - **Thinking effort controls and safer auto-mode decisions.** Thinking effort is now a first-class setting across the CLI, ACP, web config, and supported providers; Shift+Tab cycles available efforts in the shell, and auto-mode can deliberate with advisor feedback before sensitive or destructive approval flows.
 - **Shell sessions get cleaner recaps and rendering.** The interactive shell can show turn recaps, includes hook stdout/stderr in the transcript, improves prompt/file-mention and tool-output spacing, and uses branded browser-login result pages.
 - **MiniMax Token Plan model availability stays current.** MiniMax login and startup refresh now use the authenticated model catalog so Token Plan keys only keep models actually available to that key, while preserving user model preferences and isolating discovery failures from other provider refreshes.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.29.0`, or use the native installer for your OS (see the README install table).
 
 ## 0.28.0 (2026-05-31)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.28.0
+## 🆕 What's New in 0.29.0
 
 - **Redesigned startup welcome banner.** A cleaner footer-chip layout — the "What's new / Update available" chip now sits on the panel's bottom border, the headline/strapline/help lines align beside the robot logo, and the info grid drops its vertical separator.
 - **Terminal-aware rendering for minimal and CI terminals.** The shell UI adapts to your terminal — ASCII glyph fallbacks for `TERM=dumb` and legacy Windows code pages, a reduced-motion mode (`PYTHINKER_REDUCED_MOTION`), and `NO_COLOR`/`CLICOLOR` support — so output stays readable in CI logs, SSH panes, and bare terminals.
@@ -58,7 +58,7 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 - **More distribution channels.** Releases now include best-effort Docker/GHCR, Scoop, Nix, and manual WinGet plumbing, with channel-native update guidance where the install format supports it.
 - **Repository moved to the Pythoughts-labs GitHub org.** All GitHub URLs, install scripts, CI configuration, and the default `/feedback` repository now point to `github.com/Pythoughts-labs/pythinker-code`; configs that still reference the previous owner are auto-migrated.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.28.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.29.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -148,7 +148,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.28.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.29.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -176,7 +176,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.28.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.29.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -187,13 +187,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.28.0.exe
+.\PythinkerSetup-0.29.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.28.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.29.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -244,26 +244,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.28.0_amd64.deb
+sudo dpkg -i pythinker-code_0.29.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.28.0_arm64.deb
+sudo dpkg -i pythinker-code_0.29.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code-0.28.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code-0.28.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.28.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.29.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.28.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.29.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.28.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.29.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code-0.28.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code-0.28.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.28.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.28.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.29.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.29.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -272,8 +272,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.28.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.28.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.29.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.29.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.28.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.29.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.29.0 (2026-06-01)
+
+No breaking changes. This release is compatible with 0.28.0 user configuration, native installs, and session data.
+
 ## 0.28.0 (2026-05-31)
 
 **`.pythinker/AGENTS.md` is no longer loaded as project instructions.** Pythinker now merges only `AGENTS.md`/`agents.md` files from the project root down to the working directory. If you kept instructions solely in `.pythinker/AGENTS.md`, move them to a root or directory-level `AGENTS.md` or they will no longer apply. No action is needed if you did not use `.pythinker/AGENTS.md`.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,17 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.29.0 (2026-06-01)
+
+### What changed in this release
+
+- **Reloads pick up MCP and model changes cleanly.** `/reload` now re-reads MCP server configuration added after startup, cleans up stale MCP/model-refresh resources during same-process reloads, and `/model` starts a fresh session when switching models so old context does not carry across providers.
+- **Thinking effort controls and safer auto-mode decisions.** Thinking effort is now a first-class setting across the CLI, ACP, web config, and supported providers; Shift+Tab cycles available efforts in the shell, and auto-mode can deliberate with advisor feedback before sensitive or destructive approval flows.
+- **Shell sessions get cleaner recaps and rendering.** The interactive shell can show turn recaps, includes hook stdout/stderr in the transcript, improves prompt/file-mention and tool-output spacing, and uses branded browser-login result pages.
+- **MiniMax Token Plan model availability stays current.** MiniMax login and startup refresh now use the authenticated model catalog so Token Plan keys only keep models actually available to that key, while preserving user model preferences and isolating discovery failures from other provider refreshes.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.29.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.28.0 (2026-05-31)
 
 ### What changed in this release

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code_0.28.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code_0.28.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.28.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.28.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code_0.29.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code_0.29.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.29.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.29.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code-0.28.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.28.0/pythinker-code-0.28.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.28.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.28.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.29.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.29.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.28.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.29.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.28.0
+bash packages/linux-installer/build.sh 0.29.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.28.0_amd64.deb`
-- `pythinker-code-0.28.0.x86_64.rpm`
+- `pythinker-code_0.29.0_amd64.deb`
+- `pythinker-code-0.29.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.27.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.29.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/packages/pythinker-core/pyproject.toml
+++ b/packages/pythinker-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-core"
-version = "1.1.1"
+version = "1.2.0"
 description = "Pythinker core LLM, message, provider, and tool abstractions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.28.0"
+version = "0.29.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,7 +26,7 @@ dependencies = [
     "aiofiles>=24.0,<26.0",
     "aiohttp==3.13.5",
     "typer==0.21.1",
-    "pythinker-core[contrib]==1.1.1",
+    "pythinker-core[contrib]==1.2.0",
     # notify-py (via batrachian-toad) caps loguru at <=0.6.0 on 3.14+.
     "loguru>=0.6.0,<0.7",
     "prompt-toolkit==3.0.52",

--- a/uv.lock
+++ b/uv.lock
@@ -2402,7 +2402,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.28.0"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2507,7 +2507,7 @@ dev = [
 
 [[package]]
 name = "pythinker-core"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "packages/pythinker-core" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Automated release prep for 0.29.0, including pythinker-core 1.2.0.

After merge, publish the core package first, wait for PyPI, then publish the root release.

Tag sequence after merge:
1. pythinker-core-1.2.0
2. v0.29.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog, release notes, README, Quick Start and installer docs to reference version 0.29.0; added a 0.29.0 release entry (no breaking changes).
* **Chores**
  * Bumped project version to 0.29.0.
  * Updated pythinker-core dependency to 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->