### PR TITLE
fix(approval): fail closed when deliberation gate runs unscoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **Auto-mode destructive actions deliberate per turn and context.** Auto-deliberation now
   scopes destructive-command one-shots to the active execution context and LLM generation,
   so duplicate destructive calls in one response keep bouncing while later deliberate retries
-  and isolated subagent calls are handled independently.
+  and isolated subagent calls are handled independently. If a destructive action is ever
+  evaluated without that turn context, the gate now fails closed — it keeps deliberating
+  rather than auto-approving the action.
 - **Release packaging keeps SDK/core pins in lockstep.** The SDK's `pythinker-core`
   dependency is now updated by release automation and checked by CI/release validation,
   preventing no-sources binary builds from resolving against a stale core pin.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -25,7 +25,9 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **Auto-mode destructive actions deliberate per turn and context.** Auto-deliberation now
   scopes destructive-command one-shots to the active execution context and LLM generation,
   so duplicate destructive calls in one response keep bouncing while later deliberate retries
-  and isolated subagent calls are handled independently.
+  and isolated subagent calls are handled independently. If a destructive action is ever
+  evaluated without that turn context, the gate now fails closed — it keeps deliberating
+  rather than auto-approving the action.
 - **Release packaging keeps SDK/core pins in lockstep.** The SDK's `pythinker-core`
   dependency is now updated by release automation and checked by CI/release validation,
   preventing no-sources binary builds from resolving against a stale core pin.

--- a/src/pythinker_code/soul/approval.py
+++ b/src/pythinker_code/soul/approval.py
@@ -275,9 +275,23 @@ class Approval:
         if reason is None:
             return None
         scope = _current_deliberation_scope.get()
-        context_id = scope.context_id if scope is not None else "unscoped"
-        generation = scope.generation if scope is not None else 0
-        fingerprint = self._deliberation_fingerprint(context_id, tool_call.function.name, arguments)
+        if scope is None:
+            # Defensive fallback. The production path (PythinkerSoul._step) always binds a
+            # scope around step + tool-result collection, and the only caller of this gate
+            # (Approval.request, via a tool future created inside that scope) inherits it.
+            # Reaching here means a destructive call was gated with no turn-boundary signal,
+            # so we cannot distinguish a same-response duplicate from a deliberated re-issue.
+            # Fail CLOSED: keep bouncing rather than auto-approving a destructive action we
+            # cannot prove was deliberated. Surface it loudly — it indicates a wiring bug.
+            logger.warning(
+                "deliberation_gate reached without a deliberation scope for {tool_name}; "
+                "bouncing fail-closed (no turn boundary to authorize a retry)",
+                tool_name=tool_call.function.name,
+            )
+            return reason
+        fingerprint = self._deliberation_fingerprint(
+            scope.context_id, tool_call.function.name, arguments
+        )
         # One-shot keyed by (execution context, generation): the first sighting and any
         # same-generation duplicate are bounced; only a re-issue in a strictly LATER
         # generation of the same context is let through once. The context_id prefix prevents
@@ -285,11 +299,11 @@ class Approval:
         # shared via Approval.share()).
         prior_generation = self._state.deliberated_fingerprints.get(fingerprint)
         if prior_generation is not None:
-            if prior_generation < generation:
+            if prior_generation < scope.generation:
                 del self._state.deliberated_fingerprints[fingerprint]
                 return None
             return reason
-        self._state.deliberated_fingerprints[fingerprint] = generation
+        self._state.deliberated_fingerprints[fingerprint] = scope.generation
         return reason
 
     async def request(

--- a/tests/core/test_approval_auto.py
+++ b/tests/core/test_approval_auto.py
@@ -189,6 +189,19 @@ def test_older_generation_duplicate_destructive_call_still_bounces() -> None:
         assert approval.deliberation_gate(_shell_call("rm -rf build")) is not None
 
 
+def test_unscoped_destructive_calls_always_bounce_fail_closed() -> None:
+    # No deliberation scope means no turn-boundary signal to authorize a retry. The gate
+    # fails CLOSED: every sighting (including identical re-issues) bounces, never auto-
+    # approving a destructive action it cannot prove was deliberated. Production always
+    # binds a scope, so reaching this path is a wiring bug, not an expected flow.
+    approval = Approval(state=ApprovalState(auto=True, auto_deliberate=True))
+    assert approval.deliberation_gate(_shell_call("rm -rf build")) is not None
+    assert approval.deliberation_gate(_shell_call("rm -rf build")) is not None
+    assert approval.deliberation_gate(_shell_call("rm -rf build")) is not None
+    # Fail-closed bounce must not accumulate state for the unscoped path.
+    assert approval._state.deliberated_fingerprints == {}
+
+
 def test_deliberation_gate_conditions() -> None:
     """The gate fires only when the feature is on, we would otherwise auto-approve
     (auto OR yolo), and the command is destructive."""


### PR DESCRIPTION
## Summary

Follow-up to #56 (squash-merged). That PR scoped the auto-deliberation one-shot to `(execution context, generation)` but left the **scope-less fallback** in `Approval.deliberation_gate` storing `generation = 0`, where an identical destructive retry could never release the one-shot — and, more importantly, the prior design would have auto-approved an unscoped destructive retry, i.e. **fail-open on a security gate**.

This change makes the scope-less branch **fail closed** and explicit instead of silently degrading.

## What changed

- When no `deliberation_scope` is bound, `deliberation_gate` now **always bounces** a destructive call (never auto-approves one it cannot prove was deliberated), logs a `warning` (reaching this path signals a wiring bug), and no longer pollutes `deliberated_fingerprints` with a dead `unscoped::…: 0` entry.
- Added a regression test pinning the fail-closed contract (`test_unscoped_destructive_calls_always_bounce_fail_closed`).

## Why this is the robust choice

The scope-less branch is **unreachable in production**: every real-tool path enters via `pythinker_core.step()` wrapped in `deliberation_scope`, and tool futures inherit it through `asyncio.create_task`'s context copy; the only other `step()` callers (btw, compaction, blind-advisor) use empty/deny-all toolsets, so `request()` cannot fire there. Given that, the safe default for a destructive-action gate with no turn-boundary signal is fail-closed, and the right fix is to make the contract explicit rather than reopen a fail-open hole. A hard `assert`/`raise` on this runtime approval path would be more fragile, not more robust.

## Verification

- `tests/core/test_approval_auto.py` — passing (incl. new regression test).
- `ruff check` + `ruff format --check` — clean.
- Full `pythinker-code` suite was green on the source commit (4242 passed).

Single commit, cherry-picked clean onto current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened approval gating so destructive actions without the active turn context now fail-closed and continue deliberation rather than proceeding.

* **Tests**
  * Added test ensuring unscoped destructive calls consistently bounce and do not record deliberation fingerprints.

* **Documentation**
  * Clarified release notes explaining per-turn/context scoping for destructive one-shots and the fail-closed behavior when context is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->