### PR TITLE
chore(release): prepare 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.30.0 (2026-06-02)
+
+### What changed in this release
+
 - **ACP session close and auth errors are spec-compliant.** `session/close` now cancels any
   in-flight work and frees the session's runtime resources (MCP toolset, background refresh)
   before dropping it, instead of leaking them, per the ACP `session/close` requirement. The
@@ -30,6 +34,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
   dependency is now updated by release automation and checked by CI/release validation,
   preventing no-sources binary builds from resolving against a stale core pin.
 - **Routine dependency bumps with the breaking-change fallout fixed.** Upgrades `agent-client-protocol` to 0.10.1, `aiohttp` to 3.14.0, and `typer` to 0.26.5. Aligns the `pythinker-review` `typer` pin so the uv workspace resolves; migrates the ACP server to the 0.10 auth schema (`TerminalAuthMethod`) and expanded `Agent` protocol (`additional_directories`, `close_session`, session config options); and restores the optional-value behaviour of `--session`/`--resume` (interactive picker when used without an ID) under Typer 0.26's new argument parser.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.30.0`, or use the native installer for your OS (see the README install table).
 
 ## 0.29.0 (2026-06-01)
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,14 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.29.0
+## 🆕 What's New in 0.30.0
 
-- **Redesigned startup welcome banner.** A cleaner footer-chip layout — the "What's new / Update available" chip now sits on the panel's bottom border, the headline/strapline/help lines align beside the robot logo, and the info grid drops its vertical separator.
-- **Terminal-aware rendering for minimal and CI terminals.** The shell UI adapts to your terminal — ASCII glyph fallbacks for `TERM=dumb` and legacy Windows code pages, a reduced-motion mode (`PYTHINKER_REDUCED_MOTION`), and `NO_COLOR`/`CLICOLOR` support — so output stays readable in CI logs, SSH panes, and bare terminals.
-- **Windows updates avoid encoded PowerShell.** Native updates launch the signed Inno installer directly with Restart Manager flags instead of a `powershell.exe -EncodedCommand` helper, reducing antivirus false positives, and bootstrap installs show visible `/SILENT` progress.
-- **More distribution channels.** Releases now include best-effort Docker/GHCR, Scoop, Nix, and manual WinGet plumbing, with channel-native update guidance where the install format supports it.
-- **Repository moved to the Pythoughts-labs GitHub org.** All GitHub URLs, install scripts, CI configuration, and the default `/feedback` repository now point to `github.com/Pythoughts-labs/pythinker-code`; configs that still reference the previous owner are auto-migrated.
+- **ACP session close and auth errors are spec-compliant.** `session/close` now cancels in-flight work and frees session resources before dropping the session; `authenticate` failures serialize correctly so the JSON-RPC error no longer raises `TypeError` on encode.
+- **Auto-mode destructive actions deliberate per turn and context.** Destructive-command one-shots are scoped to the active execution context; duplicate calls keep bouncing while later deliberate retries and isolated subagent calls are handled independently. Missing turn context now fails closed instead of auto-approving.
+- **Release packaging keeps SDK/core pins in lockstep.** The SDK's `pythinker-core` dependency is updated by release automation and checked by CI, preventing binary builds from resolving against a stale core pin.
+- **Routine dependency bumps.** Upgrades `agent-client-protocol` to 0.10.1, `aiohttp` to 3.14.0, and `typer` to 0.26.5 with full ACP 0.10 auth schema migration and restored `--session`/`--resume` optional-value behaviour.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.29.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.30.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -148,7 +147,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.29.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.30.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -176,7 +175,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.29.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.30.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -187,13 +186,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.29.0.exe
+.\PythinkerSetup-0.30.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.29.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.30.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -244,26 +243,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.29.0_amd64.deb
+sudo dpkg -i pythinker-code_0.30.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.29.0_arm64.deb
+sudo dpkg -i pythinker-code_0.30.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.29.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.30.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.29.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.30.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.29.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.30.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.29.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.29.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.30.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.30.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -272,8 +271,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.29.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.29.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.30.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.30.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.29.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.30.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.30.0 (2026-06-02)
+
+No breaking changes. This release is compatible with 0.29.0 user configuration, native installs, and session data.
+
 ## 0.29.0 (2026-06-01)
 
 No breaking changes. This release is compatible with 0.28.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,10 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.30.0 (2026-06-02)
+
+### What changed in this release
+
 - **ACP session close and auth errors are spec-compliant.** `session/close` now cancels any
   in-flight work and frees the session's runtime resources (MCP toolset, background refresh)
   before dropping it, instead of leaking them, per the ACP `session/close` requirement. The
@@ -32,6 +36,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
   dependency is now updated by release automation and checked by CI/release validation,
   preventing no-sources binary builds from resolving against a stale core pin.
 - **Routine dependency bumps with the breaking-change fallout fixed.** Upgrades `agent-client-protocol` to 0.10.1, `aiohttp` to 3.14.0, and `typer` to 0.26.5. Aligns the `pythinker-review` `typer` pin so the uv workspace resolves; migrates the ACP server to the 0.10 auth schema (`TerminalAuthMethod`) and expanded `Agent` protocol (`additional_directories`, `close_session`, session config options); and restores the optional-value behaviour of `--session`/`--resume` (interactive picker when used without an ID) under Typer 0.26's new argument parser.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.30.0`, or use the native installer for your OS (see the README install table).
 
 ## 0.29.0 (2026-06-01)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code_0.29.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code_0.29.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.29.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.29.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code_0.30.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code_0.30.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.30.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.30.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.29.0/pythinker-code-0.29.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.29.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.29.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.30.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.30.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.29.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.30.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.29.0
+bash packages/linux-installer/build.sh 0.30.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.29.0_amd64.deb`
-- `pythinker-code-0.29.0.x86_64.rpm`
+- `pythinker-code_0.30.0_amd64.deb`
+- `pythinker-code-0.30.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.29.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.30.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.29.0"
+version = "0.30.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2417,7 +2417,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Bumps `pythinker-code` version to `0.30.0` in `pyproject.toml` and `uv.lock`
- Moves Unreleased CHANGELOG bullets to `## 0.30.0 (2026-06-02)` in `CHANGELOG.md` and its docs mirror
- Adds `## 0.30.0` no-breaking-changes entry to `breaking-changes.md`
- Updates README "What's New" section and all `0.29.0` asset references/URLs to `0.30.0`
- Updates `docs/en/guides/getting-started.md` and `packages/linux-installer/README.md` version references

## Release notes summary

ACP session close and auth spec compliance, per-turn destructive-action deliberation scoping, SDK/core pin lockstep enforcement, and routine dependency bumps (ACP 0.10.1, aiohttp 3.14.0, typer 0.26.5).

## Local gates

All passed:
- `check_version_tag.py` ✅
- README heading + upgrade snippet grep ✅
- CHANGELOG `## 0.30.0` grep ✅
- `check_pythinker_dependency_versions.py` ✅
- `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py` — 17 passed ✅
- `make check-pythinker-code` (ruff format + ruff check + pyright) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.30.0

* **Chores**
  * Released version 0.30.0

* **Documentation**
  * Updated changelog and release notes with 0.30.0 entry
  * Updated installation guides for Windows and Linux platforms
  * Confirmed no breaking changes; 0.30.0 maintains full compatibility with 0.29.0
  * Updated all installer and package references across documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->