### PR TITLE
chore(release): prepare 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,17 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.31.0 (2026-06-02)
+
+### What changed in this release
+
 - **Release promotion no longer stalls when the Homebrew tap is broken.** The `promote-release` workflow now gates only on platform assets and PyPI; a lagging or broken Homebrew tap emits a warning annotation and step summary note but no longer blocks the GitHub Release from reaching Latest.
 - **Calmer, theme-aligned TUI rendering.** Transcript, recap, and tool-header output now use theme-standardized activity colors instead of hardcoded values, and Markdown tables render as a bordered grid (wide tables no longer collapse into a stacked-record list).
 - **Auto-mode tool approval fails closed when unattended.** In auto/non-interactive runs, an action that still needs approval under the active safe-mode/trust policy is denied with guidance instead of waiting indefinitely for an absent user, and outside-workspace writes are never auto-approved. A destructive auto-approved action is now bounced once for deliberation whenever no user is present (regardless of config), so the obvious `--yolo --auto` combination is no longer more dangerous than the `autonomous_coding` profile; the `auto_deliberate_destructive_actions` setting extends that backstop to interactive `--yolo` sessions, where a user is present but approvals are skipped.
 - **Yolo + auto mode hardened against silent over-reach.** Entering plan mode now requires confirmation in an interactive `--yolo` session (matching exit), so the plan-review checkpoint is preserved when a user is present. A `--yolo` run no longer clears or persists the workspace's safe-mode/trust state. A new `--no-yolo` flag forces yolo off for a run — overriding the `--yolo` flag, the `default_yolo` config, and any resumed session state. Resuming a session that restores yolo and/or auto now surfaces a startup warning so it is never silent.
 - **`pythinker review` validates finding evidence.** Reviewflow assembles prompts from a shared security-knowledge manifest and validates findings, handling invalid ones without failing the whole review.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.31.0`, or use the native installer for your OS (see the README install table).
 
 ## 0.30.0 (2026-06-02)
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.30.0
+## 🆕 What's New in 0.31.0
 
-- **ACP session close and auth errors are spec-compliant.** `session/close` now cancels in-flight work and frees session resources before dropping the session; `authenticate` failures serialize correctly so the JSON-RPC error no longer raises `TypeError` on encode.
-- **Auto-mode destructive actions deliberate per turn and context.** Destructive-command one-shots are scoped to the active execution context; duplicate calls keep bouncing while later deliberate retries and isolated subagent calls are handled independently. Missing turn context now fails closed instead of auto-approving.
-- **Release packaging keeps SDK/core pins in lockstep.** The SDK's `pythinker-core` dependency is updated by release automation and checked by CI, preventing binary builds from resolving against a stale core pin.
-- **Routine dependency bumps.** Upgrades `agent-client-protocol` to 0.10.1, `aiohttp` to 3.14.0, and `typer` to 0.26.5 with full ACP 0.10 auth schema migration and restored `--session`/`--resume` optional-value behaviour.
+- **Release promotion no longer stalls when the Homebrew tap is broken.** The `promote-release` workflow now gates only on platform assets and PyPI; a lagging or broken Homebrew tap emits a warning annotation but no longer blocks the GitHub Release from reaching Latest.
+- **Calmer, theme-aligned TUI rendering.** Transcript, recap, and tool-header output now use theme-standardized activity colors, and Markdown tables render as a bordered grid (wide tables no longer collapse into a stacked-record list).
+- **Auto-mode tool approval fails closed when unattended.** In auto/non-interactive runs, actions still needing approval are denied with guidance instead of waiting indefinitely; the `auto_deliberate_destructive_actions` setting extends this backstop to interactive `--yolo` sessions.
+- **Yolo + auto mode hardened against silent over-reach.** Entering plan mode requires confirmation in interactive `--yolo` sessions; a new `--no-yolo` flag overrides yolo globally; resuming a yolo/auto session surfaces a startup warning.
+- **`pythinker review` validates finding evidence.** Reviewflow assembles prompts from a shared security-knowledge manifest and validates findings without failing the whole review on invalid ones.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.30.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.31.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -147,7 +148,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.30.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.31.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -175,7 +176,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.30.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.31.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -186,13 +187,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.30.0.exe
+.\PythinkerSetup-0.31.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.30.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.31.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -243,26 +244,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.30.0_amd64.deb
+sudo dpkg -i pythinker-code_0.31.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.30.0_arm64.deb
+sudo dpkg -i pythinker-code_0.31.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.30.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.31.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.30.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.31.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.30.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.31.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.30.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.30.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.31.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.31.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -271,8 +272,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.30.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.30.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.31.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.31.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.30.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.31.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.31.0 (2026-06-02)
+
+No breaking changes. This release is compatible with 0.30.0 user configuration, native installs, and session data.
+
 ## 0.30.0 (2026-06-02)
 
 No breaking changes. This release is compatible with 0.29.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,11 +17,17 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.31.0 (2026-06-02)
+
+### What changed in this release
+
 - **Release promotion no longer stalls when the Homebrew tap is broken.** The `promote-release` workflow now gates only on platform assets and PyPI; a lagging or broken Homebrew tap emits a warning annotation and step summary note but no longer blocks the GitHub Release from reaching Latest.
 - **Calmer, theme-aligned TUI rendering.** Transcript, recap, and tool-header output now use theme-standardized activity colors instead of hardcoded values, and Markdown tables render as a bordered grid (wide tables no longer collapse into a stacked-record list).
 - **Auto-mode tool approval fails closed when unattended.** In auto/non-interactive runs, an action that still needs approval under the active safe-mode/trust policy is denied with guidance instead of waiting indefinitely for an absent user, and outside-workspace writes are never auto-approved. A destructive auto-approved action is now bounced once for deliberation whenever no user is present (regardless of config), so the obvious `--yolo --auto` combination is no longer more dangerous than the `autonomous_coding` profile; the `auto_deliberate_destructive_actions` setting extends that backstop to interactive `--yolo` sessions, where a user is present but approvals are skipped.
 - **Yolo + auto mode hardened against silent over-reach.** Entering plan mode now requires confirmation in an interactive `--yolo` session (matching exit), so the plan-review checkpoint is preserved when a user is present. A `--yolo` run no longer clears or persists the workspace's safe-mode/trust state. A new `--no-yolo` flag forces yolo off for a run — overriding the `--yolo` flag, the `default_yolo` config, and any resumed session state. Resuming a session that restores yolo and/or auto now surfaces a startup warning so it is never silent.
 - **`pythinker review` validates finding evidence.** Reviewflow assembles prompts from a shared security-knowledge manifest and validates findings, handling invalid ones without failing the whole review.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.31.0`, or use the native installer for your OS (see the README install table).
 
 ## 0.30.0 (2026-06-02)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code_0.30.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code_0.30.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.30.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.30.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code_0.31.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code_0.31.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.31.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.31.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.30.0/pythinker-code-0.30.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.30.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.30.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.31.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.31.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.30.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.31.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.30.0
+bash packages/linux-installer/build.sh 0.31.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.30.0_amd64.deb`
-- `pythinker-code-0.30.0.x86_64.rpm`
+- `pythinker-code_0.31.0_amd64.deb`
+- `pythinker-code-0.31.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.30.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.31.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.30.0"
+version = "0.31.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2417,7 +2417,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.30.0"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Bumps version to `0.31.0` across `pyproject.toml`, `uv.lock`, changelogs, READMEs, and installer docs
- Promotes Unreleased CHANGELOG entries to `0.31.0 (2026-06-02)`: calmer TUI rendering, auto-mode fails-closed, yolo hardening, reviewflow validation, Homebrew tap best-effort gate
- Adds `0.31.0` no-breaking-changes entry to `breaking-changes.md`

## Test plan

- [x] `check_version_tag.py` passes
- [x] README What's New heading and upgrade snippet verified
- [x] CHANGELOG `0.31.0` entry present
- [x] `check_pythinker_dependency_versions.py` passes
- [x] `tests/test_installation_docs.py` and `tests/test_homebrew_formula.py` — 17 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released version 0.31.0 with updated release notes and guides
  * Synchronized installation instructions across Windows, Linux, and macOS platforms
  * Confirmed backward compatibility with version 0.30.0

* **Chores**
  * Updated package version to 0.31.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->