### PR TITLE
fix(windows): wipe _internal before upgrade to prevent stale dist-info version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+- **Windows upgrade version display fix.** In-place upgrades no longer show a stale version number or re-trigger the update prompt. Inno Setup now wipes `_internal` before installing new files, preventing old `dist-info` directories from accumulating and causing `importlib.metadata` to report the previous version.
+
 ## 0.31.0 (2026-06-02)
 
 ### What changed in this release

--- a/packages/windows-installer/installer.iss
+++ b/packages/windows-installer/installer.iss
@@ -47,6 +47,16 @@ Name: "modifypath"; Description: "Add Pythinker to your PATH"; \
 Name: "modifypathmachine"; Description: "Add Pythinker to the system PATH"; \
   GroupDescription: "Shell integration:"; Check: IsAdminInstallMode
 
+[InstallDelete]
+; Remove the entire _internal directory before installing new files so that
+; in-place upgrades do not accumulate stale version-stamped dist-info dirs
+; (e.g. pythinker_code-0.28.0.dist-info alongside 0.31.0.dist-info).
+; importlib.metadata.version() picks the first match it finds, which is the
+; alphabetically-lower (older) version, causing the UI to display a stale
+; version number and re-trigger the update prompt after every upgrade.
+; _internal is 100% app payload — no user data lives there.
+Type: filesandordirs; Name: "{app}\_internal"
+
 [Files]
 Source: "..\..\dist\pythinker\*"; DestDir: "{app}"; \
   Flags: ignoreversion recursesubdirs createallsubdirs

--- a/tests/test_release_update_pipeline.py
+++ b/tests/test_release_update_pipeline.py
@@ -137,6 +137,14 @@ def test_windows_installer_signs_update_artifacts_when_credentials_are_available
     assert re.search(r"NewPath\s*:=\s*Param\s*\+\s*';'\s*\+\s*OrigPath", installer_script)
     assert not re.search(r"NewPath\s*:=\s*OrigPath\s*\+\s*';'\s*\+\s*Param", installer_script)
     assert not re.search(r"StringChangeEx\(\s*OrigPath\s*,\s*Param\s*,", installer_script)
+    # [InstallDelete] must wipe _internal before [Files] runs so that in-place
+    # upgrades never accumulate stale dist-info dirs (pythinker_code-0.28.0.dist-info
+    # alongside 0.31.0 makes importlib.metadata pick the old version first).
+    assert re.search(
+        r"\[InstallDelete\].*filesandordirs.*\{app\}\\_internal",
+        installer_script,
+        re.DOTALL,
+    )
 
     # Signing only the final setup executable leaves Smart App Control and AV
     # heuristics to inspect unsigned bundled/native helper files. Keep signing


### PR DESCRIPTION
## Summary

- Inno Setup's `ignoreversion recursesubdirs` adds/overwrites files but never removes obsolete directories, so in-place upgrades left **both** `pythinker_code-0.28.0.dist-info` and `pythinker_code-0.31.0.dist-info` under `_internal`
- `importlib.metadata.version()` returns the first path-finder match; alphabetical order puts `0.28.0` before `0.31.0`, so the running 0.31.0 binary reported its version as `0.28.0`
- This caused the UI to display a stale version number and re-trigger the update prompt on every restart after a successful in-place upgrade
- Uninstall + reinstall worked cleanly because the uninstaller wiped `{app}` entirely

**Fix:** Add `[InstallDelete]` to `installer.iss` to delete `{app}\_internal` before `[Files]` runs. `_internal` is 100% PyInstaller app payload — no user data lives there. Also adds a regression assertion to `test_release_update_pipeline.py` so this section can't be silently dropped.

## Test plan

- [ ] Existing `test_release_update_pipeline.py` suite passes (7/7) — includes new assertion that `[InstallDelete]` targets `{app}\_internal`
- [ ] `make check-pythinker-code` passes (ruff + pyright clean)
- [ ] Manual: install 0.31.0 over an existing install, verify version number shown is 0.31.0 and no update prompt fires on restart