### PR TITLE
chore(release): prepare 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,16 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.32.0 (2026-06-03)
+
+### What changed in this release
+
 - **`pythinker mcp add` no longer crashes on Windows and Linux native builds.** The PyInstaller specs were using `collect_data_files()` which silently omits the `fastmcp-*.dist-info/` sibling directory; fastmcp calls `importlib.metadata.version("fastmcp")` at import time, so every `mcp add` / `mcp list` invocation raised `PackageNotFoundError`. Switched all three specs (Windows installer, Linux installer, macOS/tarball) to `copy_metadata()` — the PyInstaller-standard hook for bundling dist-info.
 - **Pythinker work directories are automatically gitignored on startup.** When the agent starts inside a git repository, `.pythinker/`, `.pythinker-review/`, and `.pythinker-review-flow/` are silently appended to the project's `.gitignore` if missing, preventing local agent state from making the working tree dirty.
 - **Old sessions and plan files are swept on startup.** Archived session directories under `~/.pythinker/sessions/` and hero-name plan files under `~/.pythinker/plans/` older than `session_retention_days` (default 30) are removed non-interactively at startup. Set `session_retention_days = 0` to disable.
 - **Windows upgrade version display fix.** In-place upgrades no longer show a stale version number or re-trigger the update prompt. Inno Setup now wipes `_internal` before installing new files, preventing old `dist-info` directories from accumulating and causing `importlib.metadata` to report the previous version.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.32.0`, or use the native installer for your OS (see the README install table).
 
 ## 0.31.0 (2026-06-02)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-16a34a.svg?style=for-the-badge)](https://github.com/Pythoughts-labs/pythinker-code/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/Pythoughts-labs/pythinker-code/ci-pythinker-cli.yml?branch=main&label=CI&style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/Pythoughts-labs/pythinker-code/actions/workflows/ci-pythinker-cli.yml?query=branch%3Amain)
 
-[![PyPI Downloads](https://static.pepy.tech/badge/pythinker-code)](https://pepy.tech/projects/pythinker-code)
+[![PyPI Downloads](https://img.shields.io/pepy/dt/pythinker-code?style=for-the-badge&logo=pypi&logoColor=white&color=blue&label=downloads)](https://pepy.tech/projects/pythinker-code)
 [![Code style: Ruff](https://img.shields.io/badge/code%20style-ruff-f59e0b.svg?style=flat-square&logo=ruff&logoColor=white)](https://docs.astral.sh/ruff/)
 [![ACP ready](https://img.shields.io/badge/ACP-ready-7c3aed.svg?style=flat-square)](https://github.com/agentclientprotocol/agent-client-protocol)
 [![MCP tools](https://img.shields.io/badge/MCP-tools-0891b2.svg?style=flat-square)](https://modelcontextprotocol.io/)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-16a34a.svg?style=for-the-badge)](https://github.com/Pythoughts-labs/pythinker-code/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/Pythoughts-labs/pythinker-code/ci-pythinker-cli.yml?branch=main&label=CI&style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/Pythoughts-labs/pythinker-code/actions/workflows/ci-pythinker-cli.yml?query=branch%3Amain)
 
-[![PyPI Downloads](https://img.shields.io/pepy/dt/pythinker-code?style=for-the-badge&logo=pypi&logoColor=white&color=blue&label=downloads)](https://pepy.tech/projects/pythinker-code)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/pythinker-code?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/pythinker-code)
 [![Code style: Ruff](https://img.shields.io/badge/code%20style-ruff-f59e0b.svg?style=flat-square&logo=ruff&logoColor=white)](https://docs.astral.sh/ruff/)
 [![ACP ready](https://img.shields.io/badge/ACP-ready-7c3aed.svg?style=flat-square)](https://github.com/agentclientprotocol/agent-client-protocol)
 [![MCP tools](https://img.shields.io/badge/MCP-tools-0891b2.svg?style=flat-square)](https://modelcontextprotocol.io/)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-16a34a.svg?style=for-the-badge)](https://github.com/Pythoughts-labs/pythinker-code/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/Pythoughts-labs/pythinker-code/ci-pythinker-cli.yml?branch=main&label=CI&style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/Pythoughts-labs/pythinker-code/actions/workflows/ci-pythinker-cli.yml?query=branch%3Amain)
 
-[![PyPI downloads](https://assets.piptrends.com/get-last-month-downloads-badge/pythinker-code.svg)](https://piptrends.com/package/pythinker-code)
+[![PyPI Downloads](https://static.pepy.tech/badge/pythinker-code)](https://pepy.tech/projects/pythinker-code)
 [![Code style: Ruff](https://img.shields.io/badge/code%20style-ruff-f59e0b.svg?style=flat-square&logo=ruff&logoColor=white)](https://docs.astral.sh/ruff/)
 [![ACP ready](https://img.shields.io/badge/ACP-ready-7c3aed.svg?style=flat-square)](https://github.com/agentclientprotocol/agent-client-protocol)
 [![MCP tools](https://img.shields.io/badge/MCP-tools-0891b2.svg?style=flat-square)](https://modelcontextprotocol.io/)
@@ -50,15 +50,14 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.31.0
+## 🆕 What's New in 0.32.0
 
-- **Release promotion no longer stalls when the Homebrew tap is broken.** The `promote-release` workflow now gates only on platform assets and PyPI; a lagging or broken Homebrew tap emits a warning annotation but no longer blocks the GitHub Release from reaching Latest.
-- **Calmer, theme-aligned TUI rendering.** Transcript, recap, and tool-header output now use theme-standardized activity colors, and Markdown tables render as a bordered grid (wide tables no longer collapse into a stacked-record list).
-- **Auto-mode tool approval fails closed when unattended.** In auto/non-interactive runs, actions still needing approval are denied with guidance instead of waiting indefinitely; the `auto_deliberate_destructive_actions` setting extends this backstop to interactive `--yolo` sessions.
-- **Yolo + auto mode hardened against silent over-reach.** Entering plan mode requires confirmation in interactive `--yolo` sessions; a new `--no-yolo` flag overrides yolo globally; resuming a yolo/auto session surfaces a startup warning.
-- **`pythinker review` validates finding evidence.** Reviewflow assembles prompts from a shared security-knowledge manifest and validates findings without failing the whole review on invalid ones.
+- **`pythinker mcp add` no longer crashes on Windows and Linux native builds.** `copy_metadata()` replaces the fragile `collect_data_files()` approach in all three PyInstaller specs, so `fastmcp` and `mcp` dist-info are bundled and `importlib.metadata` resolves correctly in frozen binaries.
+- **Pythinker work directories are automatically gitignored on startup.** `.pythinker/`, `.pythinker-review/`, and `.pythinker-review-flow/` are silently added to the project's `.gitignore` when the agent starts inside a git repo, keeping the working tree clean.
+- **Old sessions and plan files are swept on startup.** Archives older than `session_retention_days` (default 30) are removed non-interactively at launch. Set `session_retention_days = 0` to disable.
+- **Windows upgrade version display fix.** Inno Setup now wipes `_internal` before installing new files, so in-place upgrades no longer show a stale version number or re-trigger the update prompt.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.31.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.32.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -148,7 +147,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.31.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.32.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -176,7 +175,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.31.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.32.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -187,13 +186,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.31.0.exe
+.\PythinkerSetup-0.32.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.31.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.32.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -244,26 +243,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.31.0_amd64.deb
+sudo dpkg -i pythinker-code_0.32.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.31.0_arm64.deb
+sudo dpkg -i pythinker-code_0.32.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.31.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code-0.32.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code-0.32.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.32.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.31.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.32.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.31.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.32.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.31.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.31.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code-0.32.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code-0.32.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.32.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.32.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -272,8 +271,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.31.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.31.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.32.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.32.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.31.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.32.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.32.0 (2026-06-03)
+
+No breaking changes. This release is compatible with 0.31.0 user configuration, native installs, and session data.
+
 ## 0.31.0 (2026-06-02)
 
 No breaking changes. This release is compatible with 0.30.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,17 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.32.0 (2026-06-03)
+
+### What changed in this release
+
+- **`pythinker mcp add` no longer crashes on Windows and Linux native builds.** The PyInstaller specs were using `collect_data_files()` which silently omits the `fastmcp-*.dist-info/` sibling directory; fastmcp calls `importlib.metadata.version("fastmcp")` at import time, so every `mcp add` / `mcp list` invocation raised `PackageNotFoundError`. Switched all three specs (Windows installer, Linux installer, macOS/tarball) to `copy_metadata()` — the PyInstaller-standard hook for bundling dist-info.
+- **Pythinker work directories are automatically gitignored on startup.** When the agent starts inside a git repository, `.pythinker/`, `.pythinker-review/`, and `.pythinker-review-flow/` are silently appended to the project's `.gitignore` if missing, preventing local agent state from making the working tree dirty.
+- **Old sessions and plan files are swept on startup.** Archived session directories under `~/.pythinker/sessions/` and hero-name plan files under `~/.pythinker/plans/` older than `session_retention_days` (default 30) are removed non-interactively at startup. Set `session_retention_days = 0` to disable.
+- **Windows upgrade version display fix.** In-place upgrades no longer show a stale version number or re-trigger the update prompt. Inno Setup now wipes `_internal` before installing new files, preventing old `dist-info` directories from accumulating and causing `importlib.metadata` to report the previous version.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.32.0`, or use the native installer for your OS (see the README install table).
+
 ## 0.31.0 (2026-06-02)
 
 ### What changed in this release

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code_0.31.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code_0.31.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.31.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.31.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code_0.32.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code_0.32.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.32.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.32.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.31.0/pythinker-code-0.31.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.31.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.31.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code-0.32.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.32.0/pythinker-code-0.32.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.32.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.32.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.31.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.32.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.31.0
+bash packages/linux-installer/build.sh 0.32.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.31.0_amd64.deb`
-- `pythinker-code-0.31.0.x86_64.rpm`
+- `pythinker-code_0.32.0_amd64.deb`
+- `pythinker-code-0.32.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.31.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.32.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.31.0"
+version = "0.32.0"
 description = "Pythinker Code is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2417,7 +2417,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Bump version `0.31.0` → `0.32.0` across `pyproject.toml`, `uv.lock`, README, docs, and installer READMEs
- Promote Unreleased CHANGELOG entries into `## 0.32.0 (2026-06-03)`
- Mirror changelog block into `docs/en/release-notes/changelog.md`; add no-breaking-changes entry to `breaking-changes.md`
- Update downloads badge from piptrends → pepy.tech

## What's in 0.32.0

- **`pythinker mcp add` no longer crashes on native builds** — switched all three PyInstaller specs to `copy_metadata()` so `fastmcp`/`mcp` dist-info is bundled
- **Pythinker work dirs auto-gitignored on startup** — `.pythinker/`, `.pythinker-review/`, `.pythinker-review-flow/` added to `.gitignore` when missing
- **Session and plan file sweep on startup** — archives older than `session_retention_days` (default 30) removed at launch
- **Windows upgrade version display fix** — Inno Setup wipes `_internal` before installing, preventing stale dist-info version reports

## Local gates passed

- `check_version_tag.py` ✅
- README `What's New in 0.32.0` heading + `pythinker-code==0.32.0` snippet ✅
- `CHANGELOG.md` `## 0.32.0 (` heading ✅
- `check_pythinker_dependency_versions.py` ✅
- `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` — 17 passed ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides, getting-started docs, and release notes to reflect version 0.32.0, including download/install instructions and “What’s New”.
* **Chores**
  * Bumped project version to 0.32.0.
  * Added 0.32.0 release notes documenting fixes: native-build crash resolution, automatic work-directory ignore, session/plan retention cleanup, and Windows upgrade display improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->