### PR TITLE
chore(release): prepare 0.35.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ subagents, skills, web/visualization UIs, and multi-provider LLM authentication.
   commit status is `success`, not `pending`/`failure` or absent — and read the review summary and
   any "Actionable comments posted: N" findings. Do not merge while CodeRabbit is still reviewing or
   on an unreviewed commit; surface unresolved actionable findings instead of merging past them.
+- **Do not manually edit auto-synced changelog files.** `docs/en/release-notes/changelog.md` is
+  generated from the root `CHANGELOG.md`; edit `CHANGELOG.md` and run `npm run sync` from `docs/`
+  instead of hand-editing the generated docs changelog.
 - **When working on a PR or GitHub Actions failure, investigate and identify the root cause first.**
   Provide the best-practice, most robust design solution; never provide fast fixes or workarounds.
   This is a hard constraint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.35.0 (2026-06-04)
+
 - **Alibaba DashScope provider and MiniMax M3 catalog.** `/login alibaba` now configures Alibaba Cloud Model Studio / DashScope Token Plan models, including workspace-compatible endpoints and native GLM thinking behavior. MiniMax API-key login now defaults to MiniMax M3 with its larger context and multimodal capabilities.
 - **Security review vulnerability intelligence.** `pythinker security-scan` can now parse dependency manifests, query OSV package advisories, look up CVE intelligence from NVD/EPSS/CISA KEV/GitHub/vendor feeds, and carry those leads into security-review prompts and reports as evidence-checked context.
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.34.0
+## 🆕 What's New in 0.35.0
 
 - **`/stats` usage dashboard.** New slash command opens an interactive TUI showing token and cost breakdown by provider/model across Today / This Week / Last Week / All Time. Powered by a static pricing table and a session collector that walks `~/.pythinker/sessions/` wire files.
 - **Z AI provider auth.** Login/logout via API key, model discovery, and OAuth selector wired into the TUI and `refresh_managed_models`.
 - **Moonshot provider auth.** Login/logout via API key, model discovery (Kimi K2.x catalog), OAuth selector wired into the TUI and `refresh_managed_models`.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.34.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.35.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -146,7 +146,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.34.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.35.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -174,7 +174,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.34.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.35.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -185,13 +185,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.34.0.exe
+.\PythinkerSetup-0.35.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.34.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.35.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -242,26 +242,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.34.0_amd64.deb
+sudo dpkg -i pythinker-code_0.35.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.34.0_arm64.deb
+sudo dpkg -i pythinker-code_0.35.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code-0.34.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code-0.34.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.34.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code-0.35.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code-0.35.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.35.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.34.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.35.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.34.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.35.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code-0.34.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code-0.34.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.34.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.34.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code-0.35.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code-0.35.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.35.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.35.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -270,8 +270,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.34.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.34.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.35.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.35.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.34.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.35.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,8 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.35.0 (2026-06-04)
+
 ## 0.34.0 (2026-06-03)
 
 No breaking changes. This release is compatible with 0.33.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -19,6 +19,9 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## 0.35.0 (2026-06-04)
 
+- **Alibaba DashScope provider and MiniMax M3 catalog.** `/login alibaba` now configures Alibaba Cloud Model Studio / DashScope Token Plan models, including workspace-compatible endpoints and native GLM thinking behavior. MiniMax API-key login now defaults to MiniMax M3 with its larger context and multimodal capabilities.
+- **Security review vulnerability intelligence.** `pythinker security-scan` can now parse dependency manifests, query OSV package advisories, look up CVE intelligence from NVD/EPSS/CISA KEV/GitHub/vendor feeds, and carry those leads into security-review prompts and reports as evidence-checked context.
+
 ## 0.34.0 (2026-06-03)
 
 ### What changed in this release

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.35.0 (2026-06-04)
+
 ## 0.34.0 (2026-06-03)
 
 ### What changed in this release

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code_0.34.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code_0.34.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.34.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.34.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code_0.35.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code_0.35.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.35.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.35.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code-0.34.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.34.0/pythinker-code-0.34.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.34.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.34.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code-0.35.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.35.0/pythinker-code-0.35.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.35.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.35.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.34.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.35.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -41,8 +41,8 @@ bash packages/linux-installer/build.sh 0.34.0
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.34.0_amd64.deb`
-- `pythinker-code-0.34.0.x86_64.rpm`
+- `pythinker-code_0.35.0_amd64.deb`
+- `pythinker-code-0.35.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -36,7 +36,7 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.34.0
+bash packages/linux-installer/build.sh 0.35.0
 ```
 
 Outputs to `dist/`:
@@ -46,7 +46,7 @@ Outputs to `dist/`:
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.34.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.35.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.34.0"
+version = "0.35.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -156,8 +157,17 @@ def rewrite_version_in_files(paths: list[Path], *, old: str, new: str) -> None:
         path.write_text(rewrite_version_strings(original, old=old, new=new), encoding="utf-8")
 
 
+def require_executable(name: str, *, recovery: str) -> str:
+    path = shutil.which(name)
+    if path is None:
+        raise ReleaseError(f"required executable `{name}` not found on PATH; {recovery}")
+    return path
+
+
 def sync_docs_changelog() -> None:
-    subprocess.run(["node", str(DOCS_CHANGELOG_SCRIPT)], cwd=REPO_ROOT / "docs", check=True)
+    """Regenerate the docs changelog; validate() preflights node before mutations."""
+    node = require_executable("node", recovery="install Node.js or add `node` to PATH")
+    subprocess.run([node, str(DOCS_CHANGELOG_SCRIPT)], cwd=REPO_ROOT / "docs", check=True)
 
 
 def _run(cmd: list[str], *, dry_run: bool, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -177,6 +187,7 @@ def _git_capture(cmd: list[str]) -> str:
 def validate(target: str) -> None:
     """Phase 1 — fail loud, no writes."""
     parse_semver(target)
+    require_executable("node", recovery="install Node.js or add `node` to PATH")
     if _git_capture(["git", "status", "--porcelain"]):
         raise ReleaseError("working tree is not clean; commit or stash first")
     _git_capture(["git", "fetch", "origin"])

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -29,15 +29,14 @@ HOST_PYPROJECT = REPO_ROOT / "packages" / "pythinker-host" / "pyproject.toml"
 REVIEW_PYPROJECT = REPO_ROOT / "packages" / "pythinker-review" / "pyproject.toml"
 SDK_PYPROJECT = REPO_ROOT / "sdks" / "pythinker-sdk" / "pyproject.toml"
 
-# Single source for the three hand-authored changelog files. validate() asserts
-# the `## Unreleased` anchor in ALL of them before any write, and rewrite()
-# promotes the SAME list — defined once so the two can never drift (atomic
-# Phase-2 guarantee: no partial-write if a docs file is missing its anchor).
+# Hand-authored changelog files. The docs changelog is intentionally excluded:
+# docs/en/release-notes/changelog.md is auto-synced from the root CHANGELOG.md
+# by docs/scripts/sync-changelog.mjs and must not be edited directly.
 CHANGELOG_FILES = (
     REPO_ROOT / "CHANGELOG.md",
-    REPO_ROOT / "docs" / "en" / "release-notes" / "changelog.md",
     REPO_ROOT / "docs" / "en" / "release-notes" / "breaking-changes.md",
 )
+DOCS_CHANGELOG_SCRIPT = REPO_ROOT / "docs" / "scripts" / "sync-changelog.mjs"
 
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 _DEP_PIN_RE = re.compile(
@@ -157,6 +156,10 @@ def rewrite_version_in_files(paths: list[Path], *, old: str, new: str) -> None:
         path.write_text(rewrite_version_strings(original, old=old, new=new), encoding="utf-8")
 
 
+def sync_docs_changelog() -> None:
+    subprocess.run(["node", str(DOCS_CHANGELOG_SCRIPT)], cwd=REPO_ROOT / "docs", check=True)
+
+
 def _run(cmd: list[str], *, dry_run: bool, check: bool = True) -> subprocess.CompletedProcess[str]:
     if dry_run:
         print(f"[dry-run] {' '.join(cmd)}")
@@ -185,8 +188,9 @@ def validate(target: str) -> None:
     if head != remote:
         raise ReleaseError("current HEAD is not origin/main; switch to main before release prep")
     assert_monotonic(current=read_project_version(ROOT_PYPROJECT), target=target)
-    # Assert the `## Unreleased` anchor in ALL changelog files BEFORE any write
-    # (same list rewrite() promotes) so Phase 2 cannot partially rewrite the tree.
+    # Assert the `## Unreleased` anchor in ALL hand-authored changelog files BEFORE
+    # any write (same list rewrite() promotes) so Phase 2 cannot partially rewrite
+    # the tree.
     for changelog in CHANGELOG_FILES:
         if _UNRELEASED_RE.search(changelog.read_text(encoding="utf-8")) is None:
             raise ReleaseError(f"{changelog} has no `## Unreleased` section")
@@ -214,6 +218,7 @@ def rewrite(target: str, *, bump_core: str | None, bump_host: str | None) -> Non
     today = date.today().isoformat()
     for changelog in CHANGELOG_FILES:
         promote_changelog(changelog, target, release_date=today)
+    sync_docs_changelog()
     rewrite_version_in_files(
         [
             REPO_ROOT / "README.md",

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Related Issue

Release prep; no linked issue.

## Description

Prepares the 0.35.0 release by:

- Bumping the root `pythinker-code` package version to 0.35.0.
- Promoting the authored Unreleased changelog entries into the 0.35.0 release section.
- Syncing generated docs changelog content from the root `CHANGELOG.md`.
- Updating README, getting-started, and Linux installer version references.
- Documenting that `docs/en/release-notes/changelog.md` must not be edited manually and updating release tooling to sync it from the canonical root changelog.

## Checklist

- [x] Changelog updated from the authored root `CHANGELOG.md`.
- [x] Docs changelog regenerated with `node docs/scripts/sync-changelog.mjs` / `npm run sync`.
- [x] Version lockstep test passed locally: `uv run pytest tests/test_version_lockstep.py -q`.
- [x] CI checks passed on the release branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added 0.35.0 release entries to changelogs and breaking-changes; updated “What’s New”, getting-started, installer, and other docs to reference 0.35.0 assets and instructions; added contributor guidance about changelog edits.
* **Chores**
  * Project version bumped to 0.35.0; installer/package filenames and install/verification commands updated; release tooling adjusted to sync docs changelog from the canonical changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->