### PR TITLE
chore(release): prepare 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,16 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.37.0 (2026-06-07)
+
 - **Agent runtime tool visibility hardening.** `PythinkerToolset` now filters the tools advertised to the model by active execution policy, permission profile, root/subagent role, and plan-mode state while preserving execution-time guards as defense in depth.
 - **Agent design upgrades.** Agent specs now carry mode/hidden/step/model-parameter metadata, built-in `ask` and `debug` primary agents are selectable with `--agent`, the new `scout` subagent handles external docs/API freshness research, and compaction summaries use a stable handoff-oriented structure.
 - **Prompt-injection defense: `UntrustedData` wrapper.** All external content returned by `ReadFile` and `FetchURL` is now wrapped in `<untrusted_data id="NONCE">…</untrusted_data>` tags before being passed to the LLM, providing a clear boundary between trusted instructions and untrusted file/web content. The `UntrustedData` primitive escapes embedded closing tags to prevent breakout attacks.
 - **Agent boundary artifacts.** New `CodingArtifact` / `VerificationResult` and `VulnerabilityArtifact` / `AuditVerdict` frozen dataclasses in `pythinker_code.utils.artifacts` enforce a typed information barrier between coder and verifier subagents.
 - **Recon-first `planner` subagent.** A new read-only `planner` built-in agent type decomposes open-ended tasks into distinct parallel seed descriptions emitted as `<recon_seeds>` JSON, enabling structured fan-out before parallel workers start.
 - **Coder artifact contract.** The `coder` subagent now emits a `<coding_artifact>` JSON block at the end of every response, providing structured handoff data (`files_changed`, `test_command`, `expected_behavior`, optional `edge_cases_claimed`) that the `verifier` subagent can consume directly.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.37.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.36.0 (2026-06-05)
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.36.0
+## 🆕 What's New in 0.37.0
 
-- **Alibaba DashScope multi-region fallback.** China-region keys now auto-detect the endpoint mismatch and reconfigure correctly instead of showing a misleading "API key is wrong" error.
-- **Alibaba Token Plan compatibility (`sk-ws-`).** `/login alibaba` now asks for the dedicated workspace endpoint, avoids unroutable Kimi entries on those endpoints, and uses DeepSeek V3.2's working non-streaming mode.
-- **Alibaba model catalog refresh.** Qwen3.7 Plus, Qwen3 Coder Plus, and Qwen3 Coder Flash added; deprecated `kimi-k2.5`, `glm-5`, and `MiniMax-M2.5` removed.
+- **Agent runtime tool visibility hardening.** `PythinkerToolset` now gates tool advertisements by execution policy, permission profile, root/subagent role, and plan-mode state — execution-time guards remain as defense in depth.
+- **Agent design upgrades.** New `ask` and `debug` primary agents selectable with `--agent`, a `scout` subagent for docs/API freshness research, richer spec metadata, and stable compaction summaries.
+- **Prompt-injection defense: `UntrustedData` wrapper.** External file and web content is wrapped in signed `<untrusted_data>` tags before reaching the LLM, with breakout-prevention escaping.
+- **Agent boundary artifacts.** Typed `CodingArtifact`/`VerificationResult` and `VulnerabilityArtifact`/`AuditVerdict` dataclasses enforce a strict information barrier between coder and verifier subagents.
+- **Recon-first `planner` subagent.** New read-only planner decomposes tasks into parallel seed descriptions via `<recon_seeds>` JSON for structured fan-out before workers start.
+- **`coder` artifact contract.** Structured `<coding_artifact>` handoff block at end of every coder response enables direct consumption by the `verifier` subagent.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.36.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.37.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -146,7 +149,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.36.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.37.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -174,7 +177,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.36.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.37.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -185,13 +188,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.36.0.exe
+.\PythinkerSetup-0.37.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.36.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.37.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -242,26 +245,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.36.0_amd64.deb
+sudo dpkg -i pythinker-code_0.37.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.36.0_arm64.deb
+sudo dpkg -i pythinker-code_0.37.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code-0.36.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code-0.36.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.36.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.37.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.36.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.37.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.36.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.37.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code-0.36.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code-0.36.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.36.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.36.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.37.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.37.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -270,8 +273,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.36.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.36.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.37.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.37.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.36.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.37.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.37.0 (2026-06-07)
+
+No breaking changes. This release is compatible with 0.36.0 user configuration, native installs, and session data.
+
 ## 0.36.0 (2026-06-05)
 
 No breaking changes. This release is compatible with 0.35.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,10 +17,16 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.37.0 (2026-06-07)
+
+- **Agent runtime tool visibility hardening.** `PythinkerToolset` now filters the tools advertised to the model by active execution policy, permission profile, root/subagent role, and plan-mode state while preserving execution-time guards as defense in depth.
+- **Agent design upgrades.** Agent specs now carry mode/hidden/step/model-parameter metadata, built-in `ask` and `debug` primary agents are selectable with `--agent`, the new `scout` subagent handles external docs/API freshness research, and compaction summaries use a stable handoff-oriented structure.
 - **Prompt-injection defense: `UntrustedData` wrapper.** All external content returned by `ReadFile` and `FetchURL` is now wrapped in `<untrusted_data id="NONCE">…</untrusted_data>` tags before being passed to the LLM, providing a clear boundary between trusted instructions and untrusted file/web content. The `UntrustedData` primitive escapes embedded closing tags to prevent breakout attacks.
 - **Agent boundary artifacts.** New `CodingArtifact` / `VerificationResult` and `VulnerabilityArtifact` / `AuditVerdict` frozen dataclasses in `pythinker_code.utils.artifacts` enforce a typed information barrier between coder and verifier subagents.
 - **Recon-first `planner` subagent.** A new read-only `planner` built-in agent type decomposes open-ended tasks into distinct parallel seed descriptions emitted as `<recon_seeds>` JSON, enabling structured fan-out before parallel workers start.
 - **Coder artifact contract.** The `coder` subagent now emits a `<coding_artifact>` JSON block at the end of every response, providing structured handoff data (`files_changed`, `test_command`, `expected_behavior`, optional `edge_cases_claimed`) that the `verifier` subagent can consume directly.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.37.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.36.0 (2026-06-05)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code_0.36.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code_0.36.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.36.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.36.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code_0.37.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code_0.37.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.37.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.37.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code-0.36.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.36.0/pythinker-code-0.36.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.36.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.36.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.37.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.37.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.36.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.37.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.36.0
+bash packages/linux-installer/build.sh 0.37.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.36.0_amd64.deb`
-- `pythinker-code-0.36.0.x86_64.rpm`
+- `pythinker-code_0.37.0_amd64.deb`
+- `pythinker-code-0.37.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.36.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.37.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.36.0"
+version = "0.37.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release 0.37.0

### What's in this release

- **Agent runtime tool visibility hardening.** `PythinkerToolset` now filters advertised tools by execution policy, permission profile, root/subagent role, and plan-mode state.
- **Agent design upgrades.** New `ask`/`debug` primary agents (`--agent`), `scout` subagent, richer spec metadata, stable compaction summaries.
- **Prompt-injection defense: `UntrustedData` wrapper.** External file/web content wrapped in signed `<untrusted_data>` tags before reaching the LLM.
- **Agent boundary artifacts.** Typed `CodingArtifact`/`VerificationResult` and `VulnerabilityArtifact`/`AuditVerdict` dataclasses enforce coder↔verifier information barrier.
- **Recon-first `planner` subagent.** Read-only planner emits `<recon_seeds>` JSON for structured fan-out.
- **`coder` artifact contract.** Structured `<coding_artifact>` handoff block for direct `verifier` consumption.

### Local gates passed

- `check_version_tag.py` ✅
- README version/What's New check ✅
- CHANGELOG entry check ✅
- `check_pythinker_dependency_versions.py` ✅
- `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py` — 17 passed ✅
- `git grep 0.36.0` (non-historical) — clean ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides and Quick Start instructions for version 0.37.0
  * Released 0.37.0 with no breaking changes; fully compatible with 0.36.0 configuration and data
  * Updated Windows, Linux, and manual installation artifact names and checksums

* **Chores**
  * Version bumped to 0.37.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->