### PR TITLE
chore(release): prepare 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,14 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.38.0 (2026-06-08)
+
 - **Quieter `/login`.** Logging in no longer prints a `RuntimeWarning` about an un-awaited `redraw_in_future` coroutine. The prompt redraw throttle now uses a coroutine-free path (`max_render_postpone_time`), eliminating the warning emitted during the login prompt handoff.
+- **Alibaba usage reporting.** `/usage` now ships a dedicated Alibaba adapter, so logging in with an Alibaba key produces a populated cost/quota panel instead of falling through to the no-adapter branch.
+- **Live model pricing from models.dev.** Cost estimates in `/usage` and the session stats panel now pull per-model input/output pricing from the models.dev catalog (fetched once and cached for 24 hours), improving cost accuracy across providers.
+- **More robust ripgrep resolution.** File search now verifies that a bundled `rg` binary can actually execute on the host platform and architecture before using it, falling back to a system or freshly downloaded ripgrep when the bundled one cannot run — fixing search failures on mismatched-architecture installs.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.38.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.37.0 (2026-06-07)
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,14 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.37.0
+## 🆕 What's New in 0.38.0
 
-- **Agent runtime tool visibility hardening.** `PythinkerToolset` now gates tool advertisements by execution policy, permission profile, root/subagent role, and plan-mode state — execution-time guards remain as defense in depth.
-- **Agent design upgrades.** New `ask` and `debug` primary agents selectable with `--agent`, a `scout` subagent for docs/API freshness research, richer spec metadata, and stable compaction summaries.
-- **Prompt-injection defense: `UntrustedData` wrapper.** External file and web content is wrapped in signed `<untrusted_data>` tags before reaching the LLM, with breakout-prevention escaping.
-- **Agent boundary artifacts.** Typed `CodingArtifact`/`VerificationResult` and `VulnerabilityArtifact`/`AuditVerdict` dataclasses enforce a strict information barrier between coder and verifier subagents.
-- **Recon-first `planner` subagent.** New read-only planner decomposes tasks into parallel seed descriptions via `<recon_seeds>` JSON for structured fan-out before workers start.
-- **`coder` artifact contract.** Structured `<coding_artifact>` handoff block at end of every coder response enables direct consumption by the `verifier` subagent.
+- **Quieter `/login`.** The login prompt handoff no longer emits a `RuntimeWarning` about an un-awaited `redraw_in_future` coroutine; the redraw throttle now uses a coroutine-free path.
+- **Alibaba `/usage` reporting.** A dedicated Alibaba usage adapter means an Alibaba login now produces a populated cost/quota panel instead of the no-adapter fallback.
+- **Live pricing from models.dev.** `/usage` and the session stats panel pull per-model pricing from the models.dev catalog (cached 24h) for more accurate cost estimates.
+- **More robust ripgrep resolution.** File search verifies a bundled `rg` can actually run on the host platform and architecture before using it, falling back to a system or freshly downloaded ripgrep otherwise.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.37.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.38.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -149,7 +147,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.37.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.38.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -177,7 +175,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.37.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.38.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -188,13 +186,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.37.0.exe
+.\PythinkerSetup-0.38.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.37.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.38.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -245,26 +243,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.37.0_amd64.deb
+sudo dpkg -i pythinker-code_0.38.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.37.0_arm64.deb
+sudo dpkg -i pythinker-code_0.38.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.37.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code-0.38.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code-0.38.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.38.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.37.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.38.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.37.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.38.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.37.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.37.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code-0.38.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code-0.38.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.38.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.38.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -273,8 +271,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.37.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.37.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.38.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.38.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.37.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.38.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.38.0 (2026-06-08)
+
+No breaking changes. This release is compatible with 0.37.0 user configuration, native installs, and session data.
+
 ## 0.37.0 (2026-06-07)
 
 No breaking changes. This release is compatible with 0.36.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,15 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.38.0 (2026-06-08)
+
+- **Quieter `/login`.** Logging in no longer prints a `RuntimeWarning` about an un-awaited `redraw_in_future` coroutine. The prompt redraw throttle now uses a coroutine-free path (`max_render_postpone_time`), eliminating the warning emitted during the login prompt handoff.
+- **Alibaba usage reporting.** `/usage` now ships a dedicated Alibaba adapter, so logging in with an Alibaba key produces a populated cost/quota panel instead of falling through to the no-adapter branch.
+- **Live model pricing from models.dev.** Cost estimates in `/usage` and the session stats panel now pull per-model input/output pricing from the models.dev catalog (fetched once and cached for 24 hours), improving cost accuracy across providers.
+- **More robust ripgrep resolution.** File search now verifies that a bundled `rg` binary can actually execute on the host platform and architecture before using it, falling back to a system or freshly downloaded ripgrep when the bundled one cannot run — fixing search failures on mismatched-architecture installs.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.38.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+
 ## 0.37.0 (2026-06-07)
 
 - **Agent runtime tool visibility hardening.** `PythinkerToolset` now filters the tools advertised to the model by active execution policy, permission profile, root/subagent role, and plan-mode state while preserving execution-time guards as defense in depth.

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code_0.37.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code_0.37.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.37.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.37.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code_0.38.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code_0.38.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.38.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.38.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.37.0/pythinker-code-0.37.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.37.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.37.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code-0.38.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.38.0/pythinker-code-0.38.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.38.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.38.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.37.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.38.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.37.0
+bash packages/linux-installer/build.sh 0.38.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.37.0_amd64.deb`
-- `pythinker-code-0.37.0.x86_64.rpm`
+- `pythinker-code_0.38.0_amd64.deb`
+- `pythinker-code-0.38.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.37.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.38.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.37.0"
+version = "0.38.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Prepares the **0.38.0** release. Tag-triggered publish runs on `v0.38.0` after merge.

## What changed in this release

- **Quieter `/login`.** No more `RuntimeWarning` about an un-awaited `redraw_in_future` coroutine; the prompt redraw throttle now uses a coroutine-free path (`max_render_postpone_time`).
- **Alibaba usage reporting.** `/usage` now ships a dedicated Alibaba adapter, producing a populated cost/quota panel instead of the no-adapter fallback.
- **Live model pricing from models.dev.** `/usage` and the session stats panel pull per-model pricing from the models.dev catalog (cached 24h) for more accurate cost estimates.
- **More robust ripgrep resolution.** File search verifies a bundled `rg` can actually execute on the host platform/arch before using it, falling back to a system or freshly downloaded ripgrep otherwise.

No breaking changes — compatible with 0.37.0 config, native installs, and session data.

## Release mechanics

- Version bumped in `pyproject.toml` + `uv.lock` (pythinker-code block only).
- `CHANGELOG.md`, `docs/en/release-notes/{changelog,breaking-changes}.md` updated; `Unreleased` reset.
- README "What's New" + all release-asset filenames/URLs and the linux-installer docs bumped 0.37.0 → 0.38.0.

Local gates (mirror CI `validate`/`check`) all pass: version-tag check, README markers, CHANGELOG header, dependency-version check, and `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` (17 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 0.38.0 Release

* **New Features**
  * Added Alibaba adapter for `/usage` cost and quota display
  * Integrated live model pricing from models.dev for cost estimates (24-hour cache)

* **Bug Fixes**
  * Resolved login warning messages
  * Enhanced file search binary validation

* **Documentation**
  * Updated installation and release documentation for 0.38.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->