### PR TITLE
chore(deps): add npm/bun coverage to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,27 @@ updates:
       # ~95 errors in `make check`). Hold until the type regression is resolved.
       - dependency-name: "click"
         versions: [">=8.4"]
+
+  # npm/bun workspaces. Dev/build tooling and the Cloudflare workers carry the
+  # bulk of the open security alerts (vitest, vite, rollup, esbuild, hono, ...).
+  # `automated-security-fixes` remediates the alerts directly; these grouped
+  # version updates keep the lockfiles current so they don't drift back.
+  - package-ecosystem: "npm"
+    directories:
+      - "/web"
+      - "/vis"
+      - "/docs"
+      - "/packages/install-counter-worker"
+      - "/examples/feedback-worker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Cap concurrent bot PRs so the queue stays reviewable.
+    open-pull-requests-limit: 5
+    # Consolidate routine bumps into a single PR per directory; isolate majors
+    # so breaking changes get their own review.
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What

Adds an `npm` `package-ecosystem` entry to `.github/dependabot.yml` covering the five tracked JS directories: `web`, `vis`, `docs` (bun), `packages/install-counter-worker`, and `examples/feedback-worker`. Grouped weekly minor/patch bumps, mirroring the existing `uv` block.

## Why

Dependabot only watched the `uv` (Python) ecosystem. The npm side had **no** version-update coverage, so the **26 open npm security alerts** (1 critical `vitest`, plus high-sev `vite`/`rollup`/`esbuild`/`hono`/`dompurify`/… — mostly dev & build tooling) had no remediation path and no bot PRs.

## Companion change

`Dependabot automated-security-fixes` has been **enabled** on the repo (was `disabled`), so the existing alert backlog now gets remediation PRs directly. This config keeps the lockfiles current so they don't drift back.

## Scope

- `blackbox/` and `.worktrees/` are gitignored and not scanned — coverage is exactly the 5 real packages.
- Unrelated to PR #89 (the agent phase-0 branch); intentionally a separate branch off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management automation configuration to improve efficiency and maintenance workflows across multiple project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->