### PR TITLE
chore(deps): hold TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # TypeScript 6.x is a major bump: it deprecates the tsconfig `baseUrl`
+      # option (TS5101) and breaks the vis/ and web/ builds. Adopting it is a
+      # coordinated monorepo migration, not four split bot PRs. Hold the major
+      # until that lands; minor/patch within the current line still flow.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Closes the recurring TypeScript 5.9→6.0 dependabot clutter (#96, #97, #98, #99).

TS 6.0 deprecates the tsconfig `baseUrl` option (TS5101) and breaks the `vis/` and `web/` builds. Adopting it is a coordinated monorepo migration, not four split bot PRs. This adds a Dependabot `ignore` for the TypeScript **major** so those PRs stop reopening weekly; minor/patch within the current line still flow.

When we're ready to migrate to TS 6.x, drop this ignore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to exclude TypeScript major version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->