### PR TITLE
chore(release): prepare 0.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.40.1 (2026-06-10)
+
 - **Windows/Linux native installers: web UI no longer 404s on `/`.** The installer CI froze the app without building the gitignored web/vis frontend bundles, so `pythinker web` opened a browser onto `GET /?token=… → 404 Not Found`. Both installer workflows now build the bundles before PyInstaller (matching the PyPI release flow — pip/wheel installs were never affected), every PyInstaller spec refuses to freeze when the bundles are missing, and a build that still lacks them serves an explanatory page on `/` (with the REST API still reachable under `/api`) instead of a bare 404.
 - **Startup banner renders on legacy Windows consoles.** The `pythinker web` / `pythinker vis` PYTHINKER banner raw-printed Unicode block art, which garbled on legacy code pages (e.g. PowerShell with cp1252) and raised `UnicodeEncodeError` when output was redirected. The banner now honors the existing ASCII-glyph detection (`PYTHINKER_ASCII_UI` / `PYTHINKER_TUI_GLYPHS=ascii` opt-ins included) with width-preserving ASCII fallbacks, and degrades per line instead of crashing when a stream rejects Unicode.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.40.1`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.40.0 (2026-06-10)
 

--- a/README.md
+++ b/README.md
@@ -50,17 +50,12 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.40.0
+## 🆕 What's New in 0.40.1
 
-- **Alibaba: plan-key routing fixed, live model discovery, and `qwen3.7-plus` default.** Token Plan keys (`sk-sp-`, `sk-tok-`, `sk-ws-`) now route to the correct endpoint — `sk-sp-` was previously sent to the Coding Plan host, causing 401s. Model discovery no longer filters to a hardcoded allowlist; every chat model the endpoint returns now appears, so Token Plan users see the full multi-vendor set (Qwen, DeepSeek, GLM, Kimi, MiniMax). First-login default is `qwen3.7-plus`.
-- **Qwen3.x models always-thinking on both Alibaba plans.** Qwen3.x/3.7 models carry the `always_thinking` capability on Alibaba Model Studio and OpenCode Go plans — no effort dial, no top-border label.
-- **Web: same-origin WebSockets, synced version banner, and token bootstrap fix.** An empty allowed-origin list no longer rejects all WebSocket connections with a 403; the UI banner prefers the version the running backend reports; the initial auth-token race is resolved. `ESC` reliably clears only turn-spawned background tasks.
-- **Security, correctness, and multi-instance hardening.** Permission gate closes awk-pipe and `xargs -L N` shell-out bypasses. Glob enforces workspace boundary via resolved symlinks. Multi-instance sessions use a per-session writer lock; the shared metadata index uses locked read-modify-write; JSONL appenders repair torn final lines. OAuth refresh carries lifetime forward on missing `expires_in`.
-- **Thinking effort: single top-right label, input border stays neutral.** The border no longer recolors per effort level. Effort is shown once as a level-colored dot+label flushed to the right of the input's top border, hidden for always-thinking and non-thinking models.
-- **TUI refinements and agent prompt overhaul.** Adaptive terminal-background probe, unified todo renderer, elapsed/tokens/t-s status line, consistent diff palette. All default agent prompts restructured with Mission / Hard Constraints / Workflow / Output Contract sections.
-- **Breaking: `pythinker web` / `pythinker vis` host flag is now `-H`.** `-h` is now a help alias. Scripts using `-h 0.0.0.0` must switch to `-H <ip>` or `--host <ip>`.
+- **Windows/Linux native installers: web UI no longer 404s on `/`.** The installer CI froze the app without building the gitignored web/vis frontend bundles, so `pythinker web` opened a browser onto `GET /?token=… → 404 Not Found`. Both installer workflows now build the bundles before PyInstaller (matching the PyPI release flow — pip/wheel installs were never affected), every PyInstaller spec refuses to freeze when the bundles are missing, and a build that still lacks them serves an explanatory 503 page instead of a bare 404.
+- **Startup banner renders on legacy Windows consoles.** `pythinker web` / `pythinker vis` now honor the existing ASCII-glyph detection with width-preserving fallbacks and degrade per line instead of crashing when the output stream rejects Unicode (e.g. PowerShell with cp1252).
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.40.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.40.1`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -150,7 +145,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.40.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.40.1.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -178,7 +173,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.40.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.40.1.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -189,13 +184,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.40.0.exe
+.\PythinkerSetup-0.40.1.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.40.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.40.1.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -246,26 +241,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.40.0_amd64.deb
+sudo dpkg -i pythinker-code_0.40.1_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.40.0_arm64.deb
+sudo dpkg -i pythinker-code_0.40.1_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code-0.40.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code-0.40.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.40.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code-0.40.1.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code-0.40.1.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.40.1.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.40.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.40.1.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.40.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.40.1.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code-0.40.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code-0.40.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.40.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.40.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code-0.40.1.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code-0.40.1.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.40.1.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.40.1.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -274,8 +269,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.40.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.40.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.40.1_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.40.1.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.40.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.40.1.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.40.1 (2026-06-10)
+
+No breaking changes. This release is compatible with 0.40.0 user configuration, native installs, and session data.
+
 ## 0.40.0 (2026-06-10)
 
 **`pythinker web` / `pythinker vis` `-h` host flag renamed to `-H`.** The short flag `-h` is now a help alias on both subcommands (matching the root CLI); previously `-h <ip>` bound the host. Scripts using `-h 0.0.0.0` must switch to `-H <ip>` or `--host <ip>`.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,13 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.40.1 (2026-06-10)
+
+- **Windows/Linux native installers: web UI no longer 404s on `/`.** The installer CI froze the app without building the gitignored web/vis frontend bundles, so `pythinker web` opened a browser onto `GET /?token=… → 404 Not Found`. Both installer workflows now build the bundles before PyInstaller (matching the PyPI release flow — pip/wheel installs were never affected), every PyInstaller spec refuses to freeze when the bundles are missing, and a build that still lacks them serves an explanatory page on `/` (with the REST API still reachable under `/api`) instead of a bare 404.
+- **Startup banner renders on legacy Windows consoles.** The `pythinker web` / `pythinker vis` PYTHINKER banner raw-printed Unicode block art, which garbled on legacy code pages (e.g. PowerShell with cp1252) and raised `UnicodeEncodeError` when output was redirected. The banner now honors the existing ASCII-glyph detection (`PYTHINKER_ASCII_UI` / `PYTHINKER_TUI_GLYPHS=ascii` opt-ins included) with width-preserving ASCII fallbacks, and degrades per line instead of crashing when a stream rejects Unicode.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.40.1`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+
 ## 0.40.0 (2026-06-10)
 
 - **Web: same-origin WebSockets accepted, version banner synced to the backend, and token bootstrap race fixed.** The local-mode web server now auto-populates the allowed-origin list (an empty allowlist rejects every `Origin`-bearing request, which previously broke all WebSocket handshakes with a 403). The UI version banner prefers the version the running backend reports (via the config API) over the stale build-time constant, and a transient version-fetch failure no longer permanently disables the backend banner for the session. The initial auth-token bootstrap race that could fail the first request is resolved. `ESC` now reliably terminates only the background tasks spawned by the interrupted turn, and recall context is re-framed so prior-session snippets can't be misread as new instructions.

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code_0.40.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code_0.40.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.40.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.40.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code_0.40.1_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code_0.40.1_amd64.deb.sha256
+sha256sum -c pythinker-code_0.40.1_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.40.1_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code-0.40.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.0/pythinker-code-0.40.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.40.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.40.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code-0.40.1.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.40.1/pythinker-code-0.40.1.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.40.1.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.40.1.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.40.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.40.1.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.40.0
+bash packages/linux-installer/build.sh 0.40.1
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.40.0_amd64.deb`
-- `pythinker-code-0.40.0.x86_64.rpm`
+- `pythinker-code_0.40.1_amd64.deb`
+- `pythinker-code-0.40.1.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.40.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.40.1-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.40.0"
+version = "0.40.1"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.40.0"
+version = "0.40.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

Hotfix release for Windows/Linux native installer regressions introduced in 0.40.0:

- **Web UI 404 on `/` in native installers.** Installer CI froze the app without building the gitignored web/vis frontend bundles. Both `windows-installer.yml` and `linux-installer.yml` now build the bundles before PyInstaller. Every spec aborts loudly on missing assets. Apps serve an explanatory 503 page as last-resort fallback.
- **Startup banner crashes on legacy Windows code pages.** `print_banner()` now uses the existing ASCII-glyph detection with width-preserving fallbacks and per-line degradation instead of raising `UnicodeEncodeError` on cp1252/redirected stdout.

pip/wheel installs (PyPI) were never affected — this only impacts users on the native Windows installer or Linux `.deb`/`.rpm` packages.

## Test plan

- [ ] All local gates pass: `check_version_tag`, README grep, CHANGELOG grep, `check_pythinker_dependency_versions`, `test_installation_docs`, `test_homebrew_formula`
- [ ] Required CI checks green before merge
- [ ] After merge: squash-merge, pull main, push `v0.40.1` tag to trigger release workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native Windows and Linux installers to prevent web UI 404 errors on the root path when bundled assets are unavailable.
  * Improved startup banner rendering on legacy Windows consoles with ASCII fallback support.

* **Documentation**
  * Updated installation and upgrade documentation for version 0.40.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->