### PR TITLE
chore(release): prepare 0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.44.0 (2026-06-13)
+
+- **Toggle auto-update from the CLI.** Running `/update` now opens a menu — *Check for updates now* (the default, so a bare `/update` + Enter still checks immediately) or *Auto-update on startup* with its current state — so the toggle is discoverable without knowing a subcommand. `/update auto on|off` still sets it directly, and `/update auto` with no value opens an interactive On/Off picker (cursor defaulted to the current setting). The same toggle appears in the interactive `/settings` panel, and `pythinker info` reports the auto-update status. All surfaces show the *effective* state — an external override (`PYTHINKER_CLI_NO_AUTO_UPDATE` or a source checkout) is surfaced as the reason, renders the `/settings` row read-only, and makes `/update auto` report the read-only state rather than popping a no-op picker, so the toggle is never a silent no-op.
 - **Windows in-app update no longer shows a spurious "could not close the program" error.** The native installer now waits for the launching `pythinker.exe` to fully exit (its PID is passed via `/PID`) before its Restart Manager scan runs, so the scan no longer races the launcher's teardown into a false "close the program and retry" dialog. The update already succeeded in that case; now it completes cleanly without the alarming prompt.
 - **Simplified the Windows pip/uv/pipx update path.** Now that every shipped Windows install updates through the native installer, the Windows-only detached-spawn upgrade helper is removed; the remaining pip/uv/pipx path (a Windows source checkout, or any macOS/Linux install) runs the upgrade inline like POSIX, surfacing real command output and errors instead of a fire-and-forget process.
-- **Toggle auto-update from the CLI.** Running `/update` now opens a menu — *Check for updates now* (the default, so a bare `/update` + Enter still checks immediately) or *Auto-update on startup* with its current state — so the toggle is discoverable without knowing a subcommand. `/update auto on|off` still sets it directly, and `/update auto` with no value opens an interactive On/Off picker (cursor defaulted to the current setting). The same toggle appears in the interactive `/settings` panel, and `pythinker info` reports the auto-update status. All surfaces show the *effective* state — an external override (`PYTHINKER_CLI_NO_AUTO_UPDATE` or a source checkout) is surfaced as the reason, renders the `/settings` row read-only, and makes `/update auto` report the read-only state rather than popping a no-op picker, so the toggle is never a silent no-op.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.44.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.43.0 (2026-06-13)
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.43.0
+## 🆕 What's New in 0.44.0
 
-- **Silent startup auto-updates, on by default.** Managed and native installs now check for and apply updates in the background at startup, surfacing a restart-to-apply notice instead of a blocking prompt. Opt out with `auto_update = false` or `PYTHINKER_AUTO_UPDATE=0`; the Windows binary-replacement path no longer crashes the shell.
-- **Redesigned tracing dashboard.** The visualization dashboard (`pythinker vis`) gets a soft-enterprise refresh: redesigned Statistics and Sessions surfaces, a new Usage page with a usage heatmap and metric cards, and a consistent blue-accent treatment.
-- **Robust project-memory tooling.** Capacity rejections now report exact free space (delimiter-aware accounting), the `Memory` tool gains a read-only `list` action, `/memory` shows per-store capacity with a "nearly full" panel at ≥85%, and rule-/value-/file-like writes are gated behind a confirmation that steers corrections toward the authoritative file instead of silently accumulating in memory.
-- **Sharper agent guardrails.** Absence claims ("no em-dashes", "matches the source") must be backed by an actual zero-hit scan; a `designer-skill` MCP bridge routes frontend work to connected MCP tools; `best_practices_always` folds `/best-practices` guidance into every session at startup; and `StrReplaceFile` returns precise, actionable errors when a multi-edit batch fails validation.
-- **Quality of life.** `/recap on|off` with autosuggest and `<system-reminder>`-stripped recaps; a decluttered, spaced-out slash command menu with a persistent footer and `+N more` overflow; diff context lines render in normal text color; `/login` selector polish; scratch files clean up on exception exit; and error/crash telemetry is emitted at ERROR severity so it actually surfaces in dashboards.
+- **Toggle auto-update from the CLI.** `/update` now opens a menu — *Check for updates now* (the default, so a bare `/update` still checks immediately) or *Auto-update on startup* with its current state. `/update auto on|off` sets it directly, the same toggle appears in `/settings`, and `pythinker info` reports the status. Every surface shows the *effective* state, so an external override (`PYTHINKER_CLI_NO_AUTO_UPDATE` or a source checkout) is surfaced as the reason instead of silently no-opping.
+- **No more spurious "could not close the program" error on Windows updates.** The native installer now waits for the launching `pythinker.exe` to fully exit (its PID is passed via `/PID`) before its Restart Manager scan runs, so the scan no longer races the launcher's teardown into a false "close the program and retry" dialog. The update already succeeded in that case; now it completes cleanly.
+- **Simpler Windows update path.** With every shipped Windows install updating through the native installer, the Windows-only detached-spawn upgrade helper is gone; the remaining pip/uv/pipx path runs the upgrade inline and surfaces real command output and errors instead of a fire-and-forget process.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.43.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.44.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -148,7 +146,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.43.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.44.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -176,7 +174,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.43.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.44.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -187,13 +185,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.43.0.exe
+.\PythinkerSetup-0.44.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.43.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.44.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -251,26 +249,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.43.0_amd64.deb
+sudo dpkg -i pythinker-code_0.44.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.43.0_arm64.deb
+sudo dpkg -i pythinker-code_0.44.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code-0.43.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code-0.43.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.43.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.44.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.43.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.44.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.43.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.44.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code-0.43.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code-0.43.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.43.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.43.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.44.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.44.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -279,8 +277,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.43.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.43.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.44.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.44.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.43.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.44.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.43.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.44.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.44.0 (2026-06-13)
+
+No configuration or session-data breaking changes. The Windows in-app updater fix and the new auto-update toggle are backward compatible — existing config keys, the `pythinker update` command, and persisted session data are unaffected.
+
 ## 0.43.0 (2026-06-13)
 
 No configuration or session-data breaking changes. One behavior change affects update handling:

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,14 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.44.0 (2026-06-13)
+
+- **Toggle auto-update from the CLI.** Running `/update` now opens a menu — *Check for updates now* (the default, so a bare `/update` + Enter still checks immediately) or *Auto-update on startup* with its current state — so the toggle is discoverable without knowing a subcommand. `/update auto on|off` still sets it directly, and `/update auto` with no value opens an interactive On/Off picker (cursor defaulted to the current setting). The same toggle appears in the interactive `/settings` panel, and `pythinker info` reports the auto-update status. All surfaces show the *effective* state — an external override (`PYTHINKER_CLI_NO_AUTO_UPDATE` or a source checkout) is surfaced as the reason, renders the `/settings` row read-only, and makes `/update auto` report the read-only state rather than popping a no-op picker, so the toggle is never a silent no-op.
+- **Windows in-app update no longer shows a spurious "could not close the program" error.** The native installer now waits for the launching `pythinker.exe` to fully exit (its PID is passed via `/PID`) before its Restart Manager scan runs, so the scan no longer races the launcher's teardown into a false "close the program and retry" dialog. The update already succeeded in that case; now it completes cleanly without the alarming prompt.
+- **Simplified the Windows pip/uv/pipx update path.** Now that every shipped Windows install updates through the native installer, the Windows-only detached-spawn upgrade helper is removed; the remaining pip/uv/pipx path (a Windows source checkout, or any macOS/Linux install) runs the upgrade inline like POSIX, surfacing real command output and errors instead of a fire-and-forget process.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.44.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+
 ## 0.43.0 (2026-06-13)
 
 - **Silent startup auto-updates (default on).** Managed and native installs now check for and apply updates in the background at startup, surfacing a restart-to-apply notice instead of a blocking prompt. Opt out with `auto_update = false` in config or `PYTHINKER_AUTO_UPDATE=0` in the environment. The Windows update path that replaces the running binary no longer escapes as an uncaught `SystemExit` and crashes the shell.

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code_0.43.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code_0.43.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.43.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.43.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code_0.44.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code_0.44.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.44.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.44.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code-0.43.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.43.0/pythinker-code-0.43.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.43.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.43.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.44.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.44.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.43.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.44.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.43.0
+bash packages/linux-installer/build.sh 0.44.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.43.0_amd64.deb`
-- `pythinker-code-0.43.0.x86_64.rpm`
+- `pythinker-code_0.44.0_amd64.deb`
+- `pythinker-code-0.44.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.43.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.44.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.43.0"
+version = "0.44.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.43.0"
+version = "0.44.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Release prep for **pythinker-code 0.44.0** (mechanical version bump + changelog).

## Highlights
- **Toggle auto-update from the CLI** — `/update` menu, `/update auto on|off`, `/settings` row, and `pythinker info` status, all showing the *effective* state (#133, #134).
- **Windows in-app update no longer shows a spurious "could not close the program" error** — the native installer waits for the launching `pythinker.exe` to exit (via `/PID`) before its Restart Manager scan (#135).
- **Simplified the Windows pip/uv/pipx update path** — the dead Windows-only detached-spawn helper is removed; that path now runs inline (#135).

## Scope (8 files, matches prior release)
`pyproject.toml`, `uv.lock` (pythinker-code block), `CHANGELOG.md`, `docs/en/release-notes/changelog.md` (synced via `npm run sync`), `docs/en/release-notes/breaking-changes.md`, `README.md`, `docs/en/guides/getting-started.md`, `packages/linux-installer/README.md`.

## Local gates — all green
- `check_version_tag.py` → matches 0.44.0
- README "What's New in 0.44.0" + `pythinker-code==0.44.0` markers present
- `check_pythinker_dependency_versions.py` → workspace versions consistent
- `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` → 17 passed
- No breaking changes this release.

Tag `v0.44.0` will be pushed after this merges and required checks are green.