### PR TITLE
chore(release): prepare 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,14 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.45.0 (2026-06-14)
+
 - **Agent-tracing dashboard.** Added `pythinker dashboard` — a local web UI for inspecting sessions, wire events, context messages, tool statistics, and usage over time. It is also reachable from the interactive shell via the `/reports` slash command (aliased `/dashboard`).
 - **Gemini finish_reason is now sticky once truncation is detected.** A second candidate with any non-`MAX_TOKENS` finish reason no longer overwrites a previously captured `"length"` signal at either the streaming or non-streaming path in the Google GenAI provider.
 - **Budget-exhausted and stuck-loop messages are now visible in the shell.** Both handoff messages were appended to context but never sent to the wire, so the interactive shell showed no feedback when a spend ceiling or stuck-loop exit fired. Both now emit a `TextPart` wire event so the message appears in the shell.
 - **Dark-theme prompt_toolkit border colors now match the TUI token constants.** Six stale slate hex values in `_PROMPT_STYLE_DARK` diverged from the current `border` and `border_muted` token values; they are now in sync and a parity test binds them going forward.
 - **Non-review successful agents now show a summary preview in the agent tree.** Completed subagents with a `summary_preview` now display a dim preview line in the RunAgents tree renderer (review runs continue to use the findings table instead).
 - **Non-string values in `required_mcp_servers` YAML are silently dropped.** Integers, booleans, and `null` entries were previously coerced to strings (`"1"`, `"False"`, `"None"`), creating permanently unsatisfiable MCP server names. Only actual string entries are now retained.
-
 - **Fixed MiniMax token-plan `/usage` accuracy.** The token-plan response now meters by
   percentage (the count fields are 0) and reports reset times in milliseconds; the adapter was
   reading the zero counts (showing "0 requests used") and treating milliseconds as seconds
@@ -100,6 +101,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
   answer treated as complete — the model is nudged to continue from where it stopped, up
   to `loop_control.max_truncation_recoveries` times per turn (default 3; `0` disables).
   pythinker-core now surfaces the provider's truncation signal so the loop can detect it.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.45.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.44.0 (2026-06-13)
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.44.0
+## 🆕 What's New in 0.45.0
 
-- **Toggle auto-update from the CLI.** `/update` now opens a menu — *Check for updates now* (the default, so a bare `/update` still checks immediately) or *Auto-update on startup* with its current state. `/update auto on|off` sets it directly, the same toggle appears in `/settings`, and `pythinker info` reports the status. Every surface shows the *effective* state, so an external override (`PYTHINKER_CLI_NO_AUTO_UPDATE` or a source checkout) is surfaced as the reason instead of silently no-opping.
-- **No more spurious "could not close the program" error on Windows updates.** The native installer now waits for the launching `pythinker.exe` to fully exit (its PID is passed via `/PID`) before its Restart Manager scan runs, so the scan no longer races the launcher's teardown into a false "close the program and retry" dialog. The update already succeeded in that case; now it completes cleanly.
-- **Simpler Windows update path.** With every shipped Windows install updating through the native installer, the Windows-only detached-spawn upgrade helper is gone; the remaining pip/uv/pipx path runs the upgrade inline and surfaces real command output and errors instead of a fire-and-forget process.
+- **Agent-tracing dashboard.** `pythinker dashboard` opens a local web UI for inspecting sessions, wire events, context messages, tool statistics, and usage over time — also reachable from the shell via `/reports` or `/dashboard`.
+- **Project instructions immune to compaction.** `AGENTS.md` is now delivered as a fresh `<system-reminder>` on every request instead of being baked into the system prompt, so compaction can never summarize it away and the token budget can never truncate it. `pythinker system-prompt` shows the assembled prompt with the reminder below a labeled divider.
+- **Accept-edits mode.** `/accept-edits` auto-approves reversible in-workspace file edits while still prompting for shell, destructive, config, and sensitive host-file writes (`.git/hooks`, `.zshrc`, `.ssh`, etc.) — never swept into the auto-approve tier.
+- **Recover from output-token truncation.** When a turn is cut off by the output-token limit, the model is nudged to continue from where it stopped (up to `loop_control.max_truncation_recoveries` times, default 3) instead of treating a half-finished answer as complete.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.44.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.45.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -146,7 +147,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.44.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.45.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -174,7 +175,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.44.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.45.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -185,13 +186,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.44.0.exe
+.\PythinkerSetup-0.45.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.44.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.45.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -249,26 +250,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.44.0_amd64.deb
+sudo dpkg -i pythinker-code_0.45.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.44.0_arm64.deb
+sudo dpkg -i pythinker-code_0.45.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.44.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.45.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.44.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.45.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.44.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.45.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.44.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.44.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.45.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.45.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -277,8 +278,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.44.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.44.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.45.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.45.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.44.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.45.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.44.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.45.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.45.0 (2026-06-14)
+
+No breaking changes. This release is compatible with 0.44.0 user configuration, native installs, and session data.
+
 ## 0.44.0 (2026-06-13)
 
 No configuration or session-data breaking changes. The Windows in-app updater fix and the new auto-update toggle are backward compatible — existing config keys, the `pythinker update` command, and persisted session data are unaffected.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,13 +17,14 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.45.0 (2026-06-14)
+
 - **Agent-tracing dashboard.** Added `pythinker dashboard` — a local web UI for inspecting sessions, wire events, context messages, tool statistics, and usage over time. It is also reachable from the interactive shell via the `/reports` slash command (aliased `/dashboard`).
 - **Gemini finish_reason is now sticky once truncation is detected.** A second candidate with any non-`MAX_TOKENS` finish reason no longer overwrites a previously captured `"length"` signal at either the streaming or non-streaming path in the Google GenAI provider.
 - **Budget-exhausted and stuck-loop messages are now visible in the shell.** Both handoff messages were appended to context but never sent to the wire, so the interactive shell showed no feedback when a spend ceiling or stuck-loop exit fired. Both now emit a `TextPart` wire event so the message appears in the shell.
 - **Dark-theme prompt_toolkit border colors now match the TUI token constants.** Six stale slate hex values in `_PROMPT_STYLE_DARK` diverged from the current `border` and `border_muted` token values; they are now in sync and a parity test binds them going forward.
 - **Non-review successful agents now show a summary preview in the agent tree.** Completed subagents with a `summary_preview` now display a dim preview line in the RunAgents tree renderer (review runs continue to use the findings table instead).
 - **Non-string values in `required_mcp_servers` YAML are silently dropped.** Integers, booleans, and `null` entries were previously coerced to strings (`"1"`, `"False"`, `"None"`), creating permanently unsatisfiable MCP server names. Only actual string entries are now retained.
-
 - **Fixed MiniMax token-plan `/usage` accuracy.** The token-plan response now meters by
   percentage (the count fields are 0) and reports reset times in milliseconds; the adapter was
   reading the zero counts (showing "0 requests used") and treating milliseconds as seconds
@@ -102,6 +103,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
   answer treated as complete — the model is nudged to continue from where it stopped, up
   to `loop_control.max_truncation_recoveries` times per turn (default 3; `0` disables).
   pythinker-core now surfaces the provider's truncation signal so the loop can detect it.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.45.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.44.0 (2026-06-13)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code_0.44.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code_0.44.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.44.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.44.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code_0.45.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code_0.45.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.45.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.45.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.44.0/pythinker-code-0.44.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.44.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.44.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.45.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.45.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.44.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.45.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.44.0
+bash packages/linux-installer/build.sh 0.45.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.44.0_amd64.deb`
-- `pythinker-code-0.44.0.x86_64.rpm`
+- `pythinker-code_0.45.0_amd64.deb`
+- `pythinker-code-0.45.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.44.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.45.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.44.0"
+version = "0.45.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.44.0"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Bumps version from `0.44.0` → `0.45.0` across `pyproject.toml`, `uv.lock`, `README.md`, install docs, and linux-installer README
- Moves `## Unreleased` entries into `## 0.45.0 (2026-06-14)` in `CHANGELOG.md`; resets Unreleased to empty
- Syncs `docs/en/release-notes/changelog.md` via `npm run sync`
- Adds `## 0.45.0 (2026-06-14)` entry to `docs/en/release-notes/breaking-changes.md` (no breaking changes)
- Updates README "What's New" section with 0.45.0 highlights

## Key highlights in 0.45.0

- **Agent-tracing dashboard** (`pythinker dashboard` / `/reports`)
- **Project instructions immune to compaction** — AGENTS.md delivered as a fresh system-reminder preamble
- **Accept-edits mode** — `/accept-edits` toggle for reversible in-workspace edits
- **Recover from output-token truncation** — model nudged to continue after cutoff
- **Stale-overwrite guard**, **sensitive host file re-confirm**, **per-session spend ceiling**, **parallel tool fan-out cap**, MiniMax/GLM-5.2/Kimi K2.7 fixes, and more (20 items total)

## Verification

All local gates passed:
- `check_version_tag.py` — ✅
- `check_pythinker_dependency_versions.py` — ✅
- `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` — ✅ 17 passed