### PR TITLE
chore(release): prepare 0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.46.0 (2026-06-14)
+
 - **Startup auto-update now picks up new releases within half an hour instead of up to a day.** The background update check was throttled to once every 24h, so a freshly published release could go unnoticed for a full day after the last check; the interval is now 30 minutes. The silent installer also no longer marks the throttle *before* the network call — a transient startup network error returns `FAILED` and is retried on the next launch instead of suppressing updates for the whole window.
 - **The welcome banner now keeps the robot mark visible in compact terminals.** Below ~68 columns the robot was dropped (it could not sit beside the welcome copy); it now stacks centered above the copy instead, so the mark stays on screen at any width that can render its Unicode glyphs. ASCII-only terminals are unaffected.
 - **A persistent update notice now sits directly under the prompt input.** When a newer release is available the footer shows a yellow `↑ Update available — vX · /update` line; once a release has been installed in the background it switches to a restart-to-apply message instead of pointing at `/update`, and it clears after you restart onto the new version. The line is suppressed for dismissed versions, disabled auto-update, and source checkouts.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.46.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.45.0 (2026-06-14)
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.45.0
+## 🆕 What's New in 0.46.0
 
-- **Agent-tracing dashboard.** `pythinker dashboard` opens a local web UI for inspecting sessions, wire events, context messages, tool statistics, and usage over time — also reachable from the shell via `/reports` or `/dashboard`.
-- **Project instructions immune to compaction.** `AGENTS.md` is now delivered as a fresh `<system-reminder>` on every request instead of being baked into the system prompt, so compaction can never summarize it away and the token budget can never truncate it. `pythinker system-prompt` shows the assembled prompt with the reminder below a labeled divider.
-- **Accept-edits mode.** `/accept-edits` auto-approves reversible in-workspace file edits while still prompting for shell, destructive, config, and sensitive host-file writes (`.git/hooks`, `.zshrc`, `.ssh`, etc.) — never swept into the auto-approve tier.
-- **Recover from output-token truncation.** When a turn is cut off by the output-token limit, the model is nudged to continue from where it stopped (up to `loop_control.max_truncation_recoveries` times, default 3) instead of treating a half-finished answer as complete.
+- **Faster auto-update detection.** The background startup update check now runs every 30 minutes instead of once a day, so a freshly published release is picked up within the hour rather than after a full day. A transient network error at startup is retried on the next launch instead of suppressing updates for the whole window.
+- **Persistent update notice under the prompt.** When a newer release is available, a yellow `↑ Update available — vX · /update` line sits directly under the input; after a background install it switches to a restart-to-apply message, then clears once you restart onto the new version. It stays out of the way for dismissed versions, disabled auto-update, and source checkouts.
+- **Welcome banner robot stays visible in narrow terminals.** Below ~68 columns the robot mark now stacks centered above the welcome copy instead of being dropped, so it stays on screen at any width that can render its Unicode glyphs.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.45.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.46.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -147,7 +146,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.45.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.46.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -175,7 +174,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.45.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.46.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -186,13 +185,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.45.0.exe
+.\PythinkerSetup-0.46.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.45.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.46.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -250,26 +249,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.45.0_amd64.deb
+sudo dpkg -i pythinker-code_0.46.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.45.0_arm64.deb
+sudo dpkg -i pythinker-code_0.46.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.45.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.46.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.45.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.46.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.45.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.46.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.45.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.45.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.46.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.46.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -278,8 +277,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.45.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.45.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.46.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.46.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.45.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.46.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.45.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.46.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.46.0 (2026-06-14)
+
+No breaking changes. This release is compatible with 0.45.0 user configuration, native installs, and session data.
+
 ## 0.45.0 (2026-06-14)
 
 No breaking changes. This release is compatible with 0.44.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,14 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.46.0 (2026-06-14)
+
+- **Startup auto-update now picks up new releases within half an hour instead of up to a day.** The background update check was throttled to once every 24h, so a freshly published release could go unnoticed for a full day after the last check; the interval is now 30 minutes. The silent installer also no longer marks the throttle *before* the network call — a transient startup network error returns `FAILED` and is retried on the next launch instead of suppressing updates for the whole window.
+- **The welcome banner now keeps the robot mark visible in compact terminals.** Below ~68 columns the robot was dropped (it could not sit beside the welcome copy); it now stacks centered above the copy instead, so the mark stays on screen at any width that can render its Unicode glyphs. ASCII-only terminals are unaffected.
+- **A persistent update notice now sits directly under the prompt input.** When a newer release is available the footer shows a yellow `↑ Update available — vX · /update` line; once a release has been installed in the background it switches to a restart-to-apply message instead of pointing at `/update`, and it clears after you restart onto the new version. The line is suppressed for dismissed versions, disabled auto-update, and source checkouts.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.46.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+
 ## 0.45.0 (2026-06-14)
 
 - **Agent-tracing dashboard.** Added `pythinker dashboard` — a local web UI for inspecting sessions, wire events, context messages, tool statistics, and usage over time. It is also reachable from the interactive shell via the `/reports` slash command (aliased `/dashboard`).

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code_0.45.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code_0.45.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.45.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.45.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code_0.46.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code_0.46.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.46.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.46.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.45.0/pythinker-code-0.45.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.45.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.45.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.46.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.46.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.45.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.46.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.45.0
+bash packages/linux-installer/build.sh 0.46.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.45.0_amd64.deb`
-- `pythinker-code-0.45.0.x86_64.rpm`
+- `pythinker-code_0.46.0_amd64.deb`
+- `pythinker-code-0.46.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.45.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.46.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.45.0"
+version = "0.46.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.45.0"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Bumps version `0.45.0` → `0.46.0` across `pyproject.toml`, `uv.lock`, `README.md`, install docs, and the linux-installer README
- Moves `## Unreleased` entries into `## 0.46.0 (2026-06-14)` in `CHANGELOG.md`; resets Unreleased to empty
- Syncs `docs/en/release-notes/changelog.md` via `npm run sync`
- Adds `## 0.46.0 (2026-06-14)` entry to `docs/en/release-notes/breaking-changes.md` (no breaking changes)
- Updates README "What's New" section with 0.46.0 highlights

## Highlights in 0.46.0

- **Faster auto-update detection** — startup update check runs every 30 min instead of once a day; transient startup network errors retry next launch
- **Persistent update notice under the prompt** — yellow `↑ Update available` line, switches to restart-to-apply after a background install
- **Welcome banner robot stays visible in narrow terminals** — stacks above the welcome copy below ~68 columns instead of being dropped

## Verification

All local gates passed:
- `check_version_tag.py --expected-version 0.46.0` — ✅
- `check_pythinker_dependency_versions.py` (all 5 packages) — ✅
- `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` — ✅ 17 passed
- `git grep 0.45.0` leaves only historical CHANGELOG/breaking-changes blocks — ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.46.0.

* **Documentation**
  * Updated installation instructions with new version references for Windows installers and Linux packages.
  * Updated CHANGELOG and README with 0.46.0 release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->