### PR TITLE
chore(release): prepare 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.47.0 (2026-06-16)
+
 - **Plugin marketplaces and activation policy.** `pythinker plugin marketplace` can add,
   refresh, install, and uninstall Claude/Codex-compatible marketplace plugins. Plugins
   installed for Claude Code or Codex are auto-detected (no symlink): their safe artifacts
@@ -100,6 +102,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **The Agent tool description now gives clearer prompt-briefing guidance.** Fresh subagents should
   receive the goal, scope, expected output contract, and verification criteria; the Haiku-style
   tool-use summary from the blackbox reference was deliberately not ported.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.47.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.46.0 (2026-06-14)
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.46.0
+## 🆕 What's New in 0.47.0
 
-- **Faster auto-update detection.** The background startup update check now runs every 30 minutes instead of once a day, so a freshly published release is picked up within the hour rather than after a full day. A transient network error at startup is retried on the next launch instead of suppressing updates for the whole window.
-- **Persistent update notice under the prompt.** When a newer release is available, a yellow `↑ Update available — vX · /update` line sits directly under the input; after a background install it switches to a restart-to-apply message, then clears once you restart onto the new version. It stays out of the way for dismissed versions, disabled auto-update, and source checkouts.
-- **Welcome banner robot stays visible in narrow terminals.** Below ~68 columns the robot mark now stacks centered above the welcome copy instead of being dropped, so it stays on screen at any width that can render its Unicode glyphs.
+- **Plugin marketplace.** `pythinker plugin marketplace` installs Claude/Codex-compatible plugins. Safe artifacts (skills, commands, agents) auto-activate; executable artifacts (hooks, MCP servers) stay opt-in. Plugin dependencies install transitively; `plugins.options` fills `${user_config.KEY}` placeholders in hook and MCP configs.
+- **Live MCP management.** `/mcp disconnect`, `/mcp reconnect`, and `/mcp refresh` update a single server's toolset without restarting. Connected servers now push `tools/list_changed` notifications, so the agent's tool inventory stays current automatically.
+- **Agent-loop hardening.** Root sessions receive a bounded git snapshot in the prompt (`git_status_injection`). `ToolSearch`, `EnterWorktree`, and `ExitWorktree` let agents discover live capabilities and isolate work in a git worktree. Proactive compaction failures hand off explicitly instead of aborting; the spend-ceiling nudge warns before the `budget_exhausted` stop.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.46.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.47.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -146,7 +146,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.46.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.47.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -174,7 +174,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.46.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.47.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -185,13 +185,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.46.0.exe
+.\PythinkerSetup-0.47.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.46.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.47.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -249,26 +249,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.46.0_amd64.deb
+sudo dpkg -i pythinker-code_0.47.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.46.0_arm64.deb
+sudo dpkg -i pythinker-code_0.47.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.46.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.47.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.46.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.47.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.46.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.47.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.46.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.46.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.47.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.47.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -277,8 +277,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.46.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.46.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.47.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.47.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.46.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.47.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.46.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.47.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.47.0 (2026-06-16)
+
+No breaking changes. This release is compatible with 0.46.0 user configuration, native installs, and session data.
+
 ## 0.46.0 (2026-06-14)
 
 No breaking changes. This release is compatible with 0.45.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.47.0 (2026-06-16)
+
 - **Plugin marketplaces and activation policy.** `pythinker plugin marketplace` can add,
   refresh, install, and uninstall Claude/Codex-compatible marketplace plugins. Plugins
   installed for Claude Code or Codex are auto-detected (no symlink): their safe artifacts
@@ -102,6 +104,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **The Agent tool description now gives clearer prompt-briefing guidance.** Fresh subagents should
   receive the goal, scope, expected output contract, and verification criteria; the Haiku-style
   tool-use summary from the blackbox reference was deliberately not ported.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.47.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.46.0 (2026-06-14)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code_0.46.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code_0.46.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.46.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.46.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code_0.47.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code_0.47.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.47.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.47.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.46.0/pythinker-code-0.46.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.46.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.46.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.47.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.47.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.46.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.47.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.46.0
+bash packages/linux-installer/build.sh 0.47.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.46.0_amd64.deb`
-- `pythinker-code-0.46.0.x86_64.rpm`
+- `pythinker-code_0.47.0_amd64.deb`
+- `pythinker-code-0.47.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.46.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.47.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.46.0"
+version = "0.47.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.46.0"
+version = "0.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Consume `## Unreleased` into `## 0.47.0 (2026-06-16)` in `CHANGELOG.md` and `docs/en/release-notes/changelog.md`
- Add `## 0.47.0 (2026-06-16)` (no breaking changes) to `docs/en/release-notes/breaking-changes.md`
- Bump version to `0.47.0` in `pyproject.toml` and `uv.lock`
- Update README What's New section and all `0.46.0` asset references to `0.47.0`
- Update version pin in `docs/en/guides/getting-started.md` and `packages/linux-installer/README.md`

## Highlights in 0.47.0

- Plugin marketplace (`pythinker plugin marketplace`) — install/manage Claude/Codex-compatible plugins with dependency resolution and `user_config` substitution
- Live MCP management — `/mcp disconnect`, `/mcp reconnect`, `/mcp refresh`; servers push `tools/list_changed` notifications automatically
- Agent-loop hardening — git snapshot injection, `ToolSearch`/`EnterWorktree`/`ExitWorktree`, explicit compaction handoff, spend-ceiling nudge

## Test plan

- [x] `check_version_tag.py` — `ok: pyproject.toml matches expected version 0.47.0`
- [x] README grep gates pass
- [x] CHANGELOG section regex gate passes
- [x] `check_pythinker_dependency_versions.py` — ok
- [x] `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py` — 17 passed
- [x] `npm run sync` from `docs/` — no diff
- [ ] CI required checks (watching)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes and installation guides for version 0.47.0 across all platforms (Windows, Linux Debian/Ubuntu, Fedora/RHEL/openSUSE)
  * Release includes plugin marketplace, live MCP server management, and agent-loop enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->