### PR TITLE
chore(release): prepare 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.48.0 (2026-06-17)
+
 - **Fix: tool outputs invisible on Anthropic-compatible proxies (GLM-5.2 via z.ai).**
   `api.z.ai/api/anthropic` only surfaces the first content block of a multi-part
   `tool_result`, so the leading `<system>` summary reached GLM-5.2 while the actual tool
@@ -165,6 +167,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **LSP robustness.** Bounded JSON-RPC frame size and graceful-shutdown timeout, document
   version tracking for `didChange`, open-document state cleared on server restart, empty
   diagnostics payloads clear stale entries, and tightened `/usage` activity-argument validation.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.48.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.47.0 (2026-06-16)
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.47.0
+## 🆕 What's New in 0.48.0
 
-- **Plugin marketplace.** `pythinker plugin marketplace` installs Claude/Codex-compatible plugins. Safe artifacts (skills, commands, agents) auto-activate; executable artifacts (hooks, MCP servers) stay opt-in. Plugin dependencies install transitively; `plugins.options` fills `${user_config.KEY}` placeholders in hook and MCP configs.
-- **Live MCP management.** `/mcp disconnect`, `/mcp reconnect`, and `/mcp refresh` update a single server's toolset without restarting. Connected servers now push `tools/list_changed` notifications, so the agent's tool inventory stays current automatically.
-- **Agent-loop hardening.** Root sessions receive a bounded git snapshot in the prompt (`git_status_injection`). `ToolSearch`, `EnterWorktree`, and `ExitWorktree` let agents discover live capabilities and isolate work in a git worktree. Proactive compaction failures hand off explicitly instead of aborting; the spend-ceiling nudge warns before the `budget_exhausted` stop.
+- **LSP code intelligence.** New `LSP` tool (go-to-definition, references, hover, symbols, call hierarchy) with plugin-backed language servers, session-scoped lifecycle, passive diagnostics after edits, and structured errors when a server lacks `implementationProvider`.
+- **TUI theme and streaming overhaul.** Centralized theme system (`/theme`), 25 Hz paced streaming, syntax-highlighted diff cards, report panel polish, and smoother interactive/non-interactive live views — no preamble ghosting, mid-stream scrollback flicker, or fossilized spinners during tool transitions.
+- **Proxy and tool-call hardening.** Tool results flatten for Anthropic-compatible proxies (fixes invisible GLM/z.ai outputs); `ToolSearch` is hidden from providers that cannot use deferred discovery; diff cards strip ANSI escapes; collapsed ReadFile cards show line counts and previews.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.47.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.48.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -146,7 +146,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.47.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.48.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -174,7 +174,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.47.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.48.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -185,13 +185,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.47.0.exe
+.\PythinkerSetup-0.48.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.47.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.48.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -249,26 +249,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.47.0_amd64.deb
+sudo dpkg -i pythinker-code_0.48.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.47.0_arm64.deb
+sudo dpkg -i pythinker-code_0.48.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.47.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code-0.48.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code-0.48.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.48.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.47.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.48.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.47.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.48.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.47.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.47.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code-0.48.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code-0.48.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.48.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.48.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -277,8 +277,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.47.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.47.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.48.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.48.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.47.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.48.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.47.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.48.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.48.0 (2026-06-17)
+
+No breaking changes. This release is compatible with 0.47.0 user configuration, native installs, and session data.
+
 ## 0.47.0 (2026-06-16)
 
 No breaking changes. This release is compatible with 0.46.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,67 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.48.0 (2026-06-17)
+
+- **Fix: tool outputs invisible on Anthropic-compatible proxies (GLM-5.2 via z.ai).**
+  `api.z.ai/api/anthropic` only surfaces the first content block of a multi-part
+  `tool_result`, so the leading `<system>` summary reached GLM-5.2 while the actual tool
+  payload was dropped — every Shell/ReadFile/Grep result read as a "success" summary with
+  no output (reproduced from a live GLM-5.2 session transcript). Tool results are now
+  flattened to a single text block for non-native hosts via a transport-keyed resolver
+  (`resolve_tool_result_mode`), while genuine `api.anthropic.com` keeps the rich
+  multi-part form. The same single-string mode is applied defensively to non-native
+  OpenAI-compatible hosts (lossless for text), most relevant to GLM served over z.ai's
+  OpenAI endpoint; genuine `api.openai.com` is unchanged.
+- **TUI: diff cards strip terminal control sequences.** Inline file-diff bodies
+  (Update/Write cards, approval and pager diffs) now sanitize ANSI/control escapes
+  from the untrusted file and model-supplied edit content before rendering, so a
+  crafted edit can no longer smuggle cursor-movement or color escapes into the
+  terminal through a diff card. Visible text is preserved.
+- **TUI: interactive resize/handoff ghosting.** Scrollback handoffs in prompt mode
+  now fully suppress the transient preamble (agent stream body, verb spinner, and
+  tips) while ``run_in_terminal`` emits permanent scrollback, so stacked
+  ``Vibing…`` rows and duplicate tips no longer fossilize during tool transitions.
+  Terminal resize triggers a hard preamble invalidation and briefly hides tips
+  while prompt_toolkit settles at the new geometry. Handoffs defer during resize
+  recovery; failed emits leave scrollback queued for retry instead of dropping it.
+  Outermost turn end always flushes completed prose even when recovery is active,
+  so PTY sessions no longer stall on ``Finalizing…`` without emitting the response.
+- **DiffLive streaming scroll geometry.** Non-interactive live streaming now uses
+  cursor-down only when the next row provably fits the visible terminal region
+  (frame origin + target row vs height); otherwise it falls back to newline scroll,
+  preventing mid-viewport overwrite when the live frame starts below the top of the
+  screen. Set `PYTHINKER_DIFF_LIVE_LOG` to trace DiffLive refresh/growth ticks.
+- **TUI: clearer collapsed ReadFile cards.** Collapsed reads now show a line-count
+  summary with the file name (e.g. `Read 140 lines from console.py`) plus a short,
+  width-capped preview of the leading lines, instead of the generic `Read 1 file`
+  that made it look like no content was returned. Empty/unknown reads stay truthful
+  (`Read 0 lines` / `Read file content`), and expanded mode still shows the full file.
+- **Cleaner terminal report rendering.** Structured ` ```report ` outputs now suppress duplicated trailing summaries, keep only artifact footers after the report, compact long finding locations, and switch large reports to a borderless dashboard layout for faster terminal scanning.
+- **Unknown subagent-type recovery hints.** Invalid types still fail loudly, but
+  `Agent`/`RunAgents` errors now include best-effort suggestions for common
+  cross-harness aliases (e.g. `general-purpose` → `coder`) and close typos when the
+  suggested subagent exists in the current session. No silent substitution; the full
+  valid-type list is unchanged.
+- **TUI: smoother agent-working streaming.** Buffered text now reveals at an even,
+  bounded rate instead of backlog-proportional lurches, and completed prose is no
+  longer committed to scrollback mid-stream — it stays in the in-place live preview
+  and is flushed once at a tool transition or turn end, so the prompt no longer
+  pops/flickers on every paragraph boundary during a stream. The prompt stays in a
+  **Finalizing** state (not a false idle `❯`) while scrollback is pending, and clipped
+  live output shows an **earlier output hidden · Ctrl+O expand** marker instead of
+  silently dropping rows.
+
+- **TUI tool-card diffs use syntax highlighting.** Edit/Write inline diffs now share the
+  approval/pager ``PythinkerSyntax`` pipeline (``tui.code_theme``, file-extension lexer) while
+  keeping the compact boxless card layout.
+- **TUI tool-card diff wrap alignment.** Compact edit/write diffs now render in a three-column
+  grid (line number, ``+``/``-`` marker, code body) so wrapped continuation rows stay aligned
+  under the code column and repeat the diff sign instead of orphaning at column 0.
+
+- **TUI: fix fossilized pinned spinner in interactive mode.** All scrollback emissions in `_PromptLiveView` (content blocks, tool cards, notifications, steer echoes, turn recaps) now route through `run_in_terminal` instead of calling `console.print` directly, preventing prompt_toolkit's ephemeral preamble from being captured into permanent scrollback. `ty` type checker is now blocking for the `pythinker-code` package.
+
+- **TUI report prose blocks:** Agent summaries with a parent bullet plus aligned field rows (`Issue` / `Anchor`, `Finding` / `Severity`, etc.) now render as structured blocks with preserved hierarchy, per-block label columns, and correct continuation wrap indent instead of flattening into sibling markdown bullets.
 - **LSP `go_to_implementation` now returns a structured error when the server does not advertise `implementationProvider`** instead of surfacing a raw exception. The client also advertises `implementation` capability during the LSP handshake so servers like Pyright enable the provider automatically.
 - **TUI Rich Live streaming matches interactive smoothness.** Non-interactive
   shell mode now emits stable markdown to scrollback during streams, drains paced
@@ -108,6 +169,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **LSP robustness.** Bounded JSON-RPC frame size and graceful-shutdown timeout, document
   version tracking for `didChange`, open-document state cleared on server restart, empty
   diagnostics payloads clear stale entries, and tightened `/usage` activity-argument validation.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.48.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.47.0 (2026-06-16)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code_0.47.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code_0.47.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.47.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.47.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code_0.48.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code_0.48.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.48.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.48.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.47.0/pythinker-code-0.47.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.47.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.47.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code-0.48.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.48.0/pythinker-code-0.48.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.48.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.48.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.47.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.48.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.47.0
+bash packages/linux-installer/build.sh 0.48.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.47.0_amd64.deb`
-- `pythinker-code-0.47.0.x86_64.rpm`
+- `pythinker-code_0.48.0_amd64.deb`
+- `pythinker-code-0.48.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.47.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.48.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.47.0"
+version = "0.48.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.47.0"
+version = "0.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Bump `pythinker-code` to **0.48.0** (TUI theme/streaming overhaul, LSP subsystem, proxy tool-result fixes).
- Promote `## Unreleased` changelog entries into `0.48.0 (2026-06-17)`; update README What's New and release-asset version strings.

## Test plan

- [x] `scripts/check_version_tag.py --expected-version 0.48.0`
- [x] `scripts/check_pythinker_dependency_versions.py`
- [x] `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py tests/test_version_lockstep.py`
- [x] `make build-web` (local bundled UI fallback version sync)

Tag `v0.48.0` after merge and CodeRabbit review.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LSP (Language Server Protocol) tool integration now available
  * TUI theme redesign and streaming performance improvements
  * Enhanced proxy configuration and tool-call stability

* **Documentation**
  * Version 0.48.0 released
  * Installation instructions updated for Windows, Linux, and macOS platforms
  * Upgrade guidance and changelog updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->