### PR TITLE
chore(release): prepare 0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,17 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
-- **Update notice renders below the input box.** The "Updated → vX. Restart to
-  apply." line now appears underneath the prompt's bottom border instead of inside
-  the input area.
+## 0.50.0 (2026-06-20)
+
 - **Silent native updates no longer crash a running session.** The downloaded
   build is now staged beside the running executable and swapped in at exit (it goes
   live on the next launch), instead of overwriting the live onefile bundle in place.
   Overwriting it mid-session corrupted later lazy imports with a
   `zlib.error: incorrect header check`. A boundary guard also converts any residual
   post-update archive-corruption crash into a clear "restart to apply" message.
+- **Update notice renders below the input box.** The "Updated → vX. Restart to
+  apply." line now appears underneath the prompt's bottom border instead of inside
+  the input area.
 
 ## 0.49.0 (2026-06-20)
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,12 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.49.0
+## 🆕 What's New in 0.50.0
 
-- **Cleaner code by default.** The agent now walks an explicit *reduction ladder* before writing code — does this need to exist at all, then the standard library, a native platform or framework feature, an already-installed dependency, one line, and only then the minimum custom code — so it reaches for the simplest working solution without trading away input validation, error handling, security, or accessibility. The same guidance layers into the `/best-practices` profile.
-- **New `cleanup-audit` skill.** A read-only, whole-repo audit that ranks over-engineering — what to delete, simplify, or replace with standard-library/platform equivalents — as the repo-wide complement to the diff-scoped `pythinker review diff --mode deslopify`. It applies no fixes.
-- **Smoother startup.** Update notices no longer appear twice; the hint now renders once on the persistent under-input line instead of also flashing as a footer toast.
+- **Safer silent updates.** The downloaded build is now staged beside the running executable and promoted at exit, instead of overwriting the live onefile bundle in place — eliminating mid-session `zlib: incorrect header check` crashes after a background update.
+- **Cleaner update notice.** The "Updated → vX. Restart to apply." line renders below the prompt's bottom border, not inside the input area.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.49.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.50.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -146,7 +145,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.49.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.50.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -174,7 +173,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.49.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.50.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -185,13 +184,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.49.0.exe
+.\PythinkerSetup-0.50.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.49.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.50.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -249,26 +248,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.49.0_amd64.deb
+sudo dpkg -i pythinker-code_0.50.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.49.0_arm64.deb
+sudo dpkg -i pythinker-code_0.50.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code-0.49.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code-0.49.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.49.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.50.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.49.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.50.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.49.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.50.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code-0.49.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code-0.49.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.49.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.49.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.50.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.50.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -277,8 +276,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.49.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.49.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.50.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.50.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.49.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.50.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.49.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.50.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.50.0 (2026-06-20)
+
+No breaking changes. This release is compatible with 0.49.0 user configuration, native installs, and session data.
+
 ## 0.49.0 (2026-06-20)
 
 No breaking changes. This release is compatible with 0.48.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,18 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.50.0 (2026-06-20)
+
+- **Silent native updates no longer crash a running session.** The downloaded
+  build is now staged beside the running executable and swapped in at exit (it goes
+  live on the next launch), instead of overwriting the live onefile bundle in place.
+  Overwriting it mid-session corrupted later lazy imports with a
+  `zlib.error: incorrect header check`. A boundary guard also converts any residual
+  post-update archive-corruption crash into a clear "restart to apply" message.
+- **Update notice renders below the input box.** The "Updated → vX. Restart to
+  apply." line now appears underneath the prompt's bottom border instead of inside
+  the input area.
+
 ## 0.49.0 (2026-06-20)
 
 - **Reduction ladder in the default agent prompt.** The agent now walks an explicit,

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code_0.49.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code_0.49.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.49.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.49.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code_0.50.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code_0.50.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.50.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.50.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code-0.49.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.49.0/pythinker-code-0.49.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.49.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.49.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.50.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.50.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.49.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.50.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.49.0
+bash packages/linux-installer/build.sh 0.50.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.49.0_amd64.deb`
-- `pythinker-code-0.49.0.x86_64.rpm`
+- `pythinker-code_0.50.0_amd64.deb`
+- `pythinker-code-0.50.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.49.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.50.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.49.0"
+version = "0.50.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.49.0"
+version = "0.50.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Bump 0.49.0 → 0.50.0: staged-update fix (no mid-session onefile corruption) + update notice below input. 8-file mechanical release bump; all local + CI gates green.

## Changes

- `pyproject.toml` / `uv.lock`: version 0.49.0 → 0.50.0
- `CHANGELOG.md` / `docs/en/release-notes/changelog.md`: Unreleased → 0.50.0 (2026-06-20)
- `docs/en/release-notes/breaking-changes.md`: 0.50.0 entry (no breaking changes)
- `README.md`: What's New 0.50.0, all version references bumped
- `docs/en/guides/getting-started.md` / `packages/linux-installer/README.md`: version references bumped

## Gate results

- ✅ `check_version_tag.py` — 0.50.0 match
- ✅ README `What's New in 0.50.0` + `pythinker-code==0.50.0` present
- ✅ `CHANGELOG.md` has `## 0.50.0 (` entry
- ✅ `check_pythinker_dependency_versions.py` — workspace versions consistent
- ✅ `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` — 17 passed
- ✅ No stale `0.49.0` references in shipped files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version 0.50.0 released with safer staged updates that swap in at application exit to prevent mid-session crashes
  * Update notice repositioned below the input box for improved UI visibility

* **Chores**
  * Updated documentation, installer instructions, and version references to 0.50.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->