### PR TITLE
chore(release): prepare 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.51.0 (2026-06-22)
+
 - **Reasoning levels now match each GPT model.** The thinking selector and
   Shift+Tab cycle scope reasoning effort to what the active OpenAI GPT-5-family
   model actually accepts — e.g. gpt-5.4/gpt-5.5 no longer offer `minimal`
@@ -45,6 +47,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
   `brew upgrade` with `HOMEBREW_NO_INSTALL_CLEANUP` and `HOMEBREW_NO_AUTO_UPDATE`,
   so brew can't delete the in-use Cellar version mid-session; the new build is
   staged side-by-side and goes live on restart.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.51.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.50.0 (2026-06-20)
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,16 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.50.0
+## 🆕 What's New in 0.51.0
 
-- **Safer silent updates.** The downloaded build is now staged beside the running executable and promoted at exit, instead of overwriting the live onefile bundle in place — eliminating mid-session `zlib: incorrect header check` crashes after a background update.
-- **Cleaner update notice.** The "Updated → vX. Restart to apply." line renders below the prompt's bottom border, not inside the input area.
+- **Model-aware thinking levels.** The thinking selector and Shift+Tab cycle now scope reasoning effort to what the active GPT-5-family model accepts; unsupported persisted levels are clamped before the API call.
+- **Cleaner diff cards.** Diff syntax highlighting no longer paints an opaque code-theme background over green/red row tints — tints show through on every terminal.
+- **Truecolor in VS Code terminals.** Integrated terminals reporting `TERM_PROGRAM=vscode` (and forks) are promoted to truecolor so diff tints don't fall back to 16-color mode.
+- **No duplicate welcome banner on reload.** Same-session reloads (`/model`, `/theme`, `/thinking`, …) keep the existing banner instead of stacking a second splash.
+- **Update notice moved to footer.** The persistent "Restart to apply" / "Update available" line renders below the status/clock row, clear of the input box.
+- **Safer Homebrew self-upgrades.** Silent `brew upgrade` runs with cleanup/auto-update disabled so the in-use Cellar version isn't deleted mid-session.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.50.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.51.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -145,7 +149,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.50.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.51.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -173,7 +177,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.50.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.51.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -184,13 +188,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.50.0.exe
+.\PythinkerSetup-0.51.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.50.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.51.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -248,26 +252,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.50.0_amd64.deb
+sudo dpkg -i pythinker-code_0.51.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.50.0_arm64.deb
+sudo dpkg -i pythinker-code_0.51.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.50.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.51.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.50.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.51.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.50.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.51.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.50.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.50.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.51.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.51.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -276,8 +280,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.50.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.50.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.51.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.51.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -31,7 +31,7 @@ Run the native installation script to complete the installation. The canonical e
 curl -fsSL https://pythinker.com/install.sh | bash
 
 # Pin a specific version
-curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.50.0
+curl -fsSL https://pythinker.com/install.sh | bash -s -- --version 0.51.0
 
 # Custom prefix (defaults to $HOME/.local)
 curl -fsSL https://pythinker.com/install.sh | bash -s -- --prefix /opt/pythinker
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.50.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.51.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.51.0 (2026-06-22)
+
+No breaking changes. This release is compatible with 0.50.0 user configuration, native installs, and session data.
+
 ## 0.50.0 (2026-06-20)
 
 No breaking changes. This release is compatible with 0.49.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,30 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.51.0 (2026-06-22)
+
+- **Reasoning levels now match each GPT model.** The thinking selector and
+  Shift+Tab cycle scope reasoning effort to what the active OpenAI GPT-5-family
+  model actually accepts — e.g. gpt-5.4/gpt-5.5 no longer offer `minimal`
+  (which they reject) and keep `xhigh`, while gpt-5.0 keeps `minimal`. A
+  persisted unsupported level is clamped to the nearest supported one before
+  it is sent, so the API never rejects it.
+- **Diff cards no longer show a "blue overlay".** The syntax highlighter no
+  longer paints the code theme's opaque background (e.g. catppuccin `#1E1E2E`)
+  onto diff lines, so the green/red row tints — and the terminal background on
+  context lines — show through on every terminal. Previously that code-theme
+  block masked the row tints and only blended where the terminal background
+  happened to match it.
+- **VS Code-family terminals are detected as truecolor.** `color_depth()` now
+  promotes integrated terminals reporting `TERM_PROGRAM=vscode` (including forks
+  built on it) to truecolor — like the existing Windows Terminal promotion — so
+  diff tints don't fall back to the colorless 16-color path when the terminal
+  doesn't advertise `COLORTERM`.
+- **Model/theme switches no longer reprint the welcome banner.** A same-session
+  reload (`/model`, `/theme`, `/thinking`, `/new`, fork, …) now keeps the
+  existing banner and shows only its own "Switched to… / Reloading…"
+  confirmation, instead of stacking a redundant second welcome splash below it.
+  `/clear` and `/reload` still wipe the screen and reprint the banner.
 - **Update notice no longer crowds the prompt.** The persistent "Restart to apply"
   / "Update available" line now renders as the last footer row — below the
   status/clock line — instead of directly under the input box, keeping the input
@@ -25,6 +49,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
   `brew upgrade` with `HOMEBREW_NO_INSTALL_CLEANUP` and `HOMEBREW_NO_AUTO_UPDATE`,
   so brew can't delete the in-use Cellar version mid-session; the new build is
   staged side-by-side and goes live on restart.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.51.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.50.0 (2026-06-20)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code_0.50.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code_0.50.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.50.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.50.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code_0.51.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code_0.51.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.51.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.51.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.50.0/pythinker-code-0.50.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.50.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.50.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.51.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.51.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.50.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.51.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,17 +36,17 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.50.0
+bash packages/linux-installer/build.sh 0.51.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.50.0_amd64.deb`
-- `pythinker-code-0.50.0.x86_64.rpm`
+- `pythinker-code_0.51.0_amd64.deb`
+- `pythinker-code-0.51.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist
-target-triple naming (e.g. `pythinker-0.50.0-x86_64-unknown-linux-gnu.tar.gz`).
+target-triple naming (e.g. `pythinker-0.51.0-x86_64-unknown-linux-gnu.tar.gz`).
 
 ## CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.50.0"
+version = "0.51.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.50.0"
+version = "0.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Bump version to **0.51.0** (`pyproject.toml`, `uv.lock`)
- Ship TUI/update fixes since v0.50.0: model-aware thinking levels, diff-card tint rendering, VS Code truecolor detection, suppressed reload welcome banner, footer update notice placement, safer Homebrew self-upgrades
- Update changelog, README "What's New", getting-started, linux-installer docs, and breaking-changes entry

## Test plan

- [x] `scripts/check_version_tag.py --expected-version 0.51.0`
- [x] README/CHANGELOG version grep checks
- [x] `scripts/check_pythinker_dependency_versions.py`
- [x] `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py`
- [x] `make build-web` (local UI bundle refresh)
- [ ] CI required checks green
- [ ] Squash-merge, then tag `v0.51.0` after confirmation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides and changelog for version 0.51.0 with upgrade instructions for Windows, Linux, and pip installations.

* **Chores**
  * Bumped project version to 0.51.0 across all distribution packages and build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->