### PR TITLE
chore(release): prepare 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.52.0 (2026-06-23)
+
 - **`InvalidToolError` now names the failing tool and the reason.** A bad
   tool path in `agent.yaml` (typo, missing class, or — most commonly — a
   `pythinker` binary built before the tool was added) used to surface as a

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.51.0
+## 🆕 What's New in 0.52.0
 
 - **Model-aware thinking levels.** The thinking selector and Shift+Tab cycle now scope reasoning effort to what the active GPT-5-family model accepts; unsupported persisted levels are clamped before the API call.
 - **Cleaner diff cards.** Diff syntax highlighting no longer paints an opaque code-theme background over green/red row tints — tints show through on every terminal.
@@ -59,7 +59,7 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 - **Update notice moved to footer.** The persistent "Restart to apply" / "Update available" line renders below the status/clock row, clear of the input box.
 - **Safer Homebrew self-upgrades.** Silent `brew upgrade` runs with cleanup/auto-update disabled so the in-use Cellar version isn't deleted mid-session.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.51.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.52.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -149,7 +149,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.51.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.52.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -177,7 +177,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.51.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.52.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -188,13 +188,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.51.0.exe
+.\PythinkerSetup-0.52.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.51.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.52.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -252,26 +252,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.51.0_amd64.deb
+sudo dpkg -i pythinker-code_0.52.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.51.0_arm64.deb
+sudo dpkg -i pythinker-code_0.52.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.51.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.52.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.51.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.52.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.51.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.52.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.51.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.51.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.52.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.52.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -280,8 +280,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.51.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.51.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.52.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.52.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.51.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.52.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,8 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.52.0 (2026-06-23)
+
 ## 0.51.0 (2026-06-22)
 
 No breaking changes. This release is compatible with 0.50.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,65 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.52.0 (2026-06-23)
+
+- **`InvalidToolError` now names the failing tool and the reason.** A bad
+  tool path in `agent.yaml` (typo, missing class, or — most commonly — a
+  `pythinker` binary built before the tool was added) used to surface as a
+  bare `Invalid tools: ['pythinker_code.tools.agent:ImplementAndJudge']`
+  with the actual reason buried in the log file. The aggregated error now
+  lists each bad tool with the per-tool reason, and a class-name miss logs
+  a `Did you mean '<Closest>'?` hint. A constructor exception on one tool
+  is caught per-tool so the user gets one clear error instead of a
+  traceback. Rebuild the binary (`make build-bin`) if the new error names
+  a tool that exists in the working tree.
+- **Auto-chain `implementer` → `judge` for non-trivial scoped edits.** The new
+  `ImplementAndJudge` tool runs `implementer` once, hands the artifact to
+  `judge`, and on `NEEDS_WORK` re-invokes `implementer` once with the
+  judge's `REQUIRED FIXES` under a `## Revision brief` section before
+  re-judging. Two implementer invocations is the hard cap — a
+  still-`NEEDS_WORK` after revision surfaces the contradiction and stops.
+  Parent agents should call `ImplementAndJudge` instead of `Agent:
+  implementer` + `Agent: judge`; bare `judge` calls remain the right shape
+  for non-implementation reviews (reports, audits, severity-scored
+  findings).
+- **Judge adopts the minimum-diff rubric dimension.** Every non-trivial diff
+  the judge reviews is now checked against the reduction ladder
+  (skip-need → reuse-stdlib → use-native → use-installed-dep → one-line →
+  minimum) and the minimum-diff rubric (no abstractions, no new deps
+  without justification, no new config keys without a consumer, no
+  reformatting churn outside the changed lines). The judge applies the full
+  ladder uniformly — there is no mode switch on the judge.
+- **Bundled judge-branded skills.** `judge-minimum-diff` (the rubric
+  applied as a judge dimension) and `judge-overengineering-review` (the
+  parent-facing review checklist) ship as static default skills, replacing
+  ad-hoc prose in the system prompt with explicit, versionable content.
+- **Fix OpenAI Responses requests that could still send `role="system"` after
+  switching to a newer Pythinker catalog model (gpt-5.5, gpt-5.3-codex,
+  gpt-5.3-codex-spark, or any user-defined fine-tune).** Pythinker observed
+  OpenAI returning `System messages are not allowed` on this path, but the
+  `system→developer` conversion was previously gated on the openai SDK's
+  `ResponsesModel` literal, which lags Pythinker's own model catalog. The
+  conversion now runs unconditionally in `OpenAIResponses`, so all local
+  system messages are normalized before sending. Also fixes the model-switch
+  carry-over path (`_carry_context_to_session`) whose seeded `role="system"`
+  summary message was sent verbatim on the first request after a switch.
+- **Background bash tasks (npm dev, docker run) no longer show the agent
+  verb spinner.** Pure-bash background work now shows a fixed "Running in
+  background…" label instead of "Composing…/Brewing…" verbs, which read as
+  agent activity. Mixed bash+agent background work keeps the verb spinner
+  while the agent is actively producing tokens.
+- **Quiet background tasks no longer force a 0.1s prompt repaint.** When a
+  background task has produced no output for 2 seconds, the refresh loop
+  drops to the idle 1.0s interval instead of spinning the braille marker at
+  12.5 fps — fixing the "stuck spinner" look for long-running dev servers
+  on Windows VS Code.
+- **Welcome banner no longer shows a stale "Update available" chip after a
+  successful /update.** The banner chip now mirrors the under-input notice:
+  when the update has landed this session (state=UPDATED, smoke check passed),
+  it shows "Updated X → vY. Restart to apply." instead of telling the user
+  to re-run an update that already completed.
+
 ## 0.51.0 (2026-06-22)
 
 - **Reasoning levels now match each GPT model.** The thinking selector and

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code_0.51.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code_0.51.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.51.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.51.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code_0.52.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code_0.52.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.52.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.52.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.51.0/pythinker-code-0.51.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.51.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.51.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.52.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.52.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.51.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.52.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -41,8 +41,8 @@ bash packages/linux-installer/build.sh 0.51.0
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.51.0_amd64.deb`
-- `pythinker-code-0.51.0.x86_64.rpm`
+- `pythinker-code_0.52.0_amd64.deb`
+- `pythinker-code-0.52.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.51.0"
+version = "0.52.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.51.0"
+version = "0.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Automated release prep for 0.52.0. Tag after merge (C1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.52.0
  * Updated installation instructions and documentation across all platforms (Windows, Linux, and system package managers) to reflect the new version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->