### PR TITLE
chore(release): prepare 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,17 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
-- Fix a fatal "Could not resolve authentication method" crash when a GPT/ChatGPT
-  session token is invalidated mid-session (e.g. the OAuth refresh token was
-  rotated by signing in on another machine). The provider now surfaces a typed
-  401 that routes into the standard re-authentication path instead of an
-  uncaught error — prompting `/login` rather than dumping a traceback.
-- Render the `ImplementAndJudge` chain as `Implement & Judge — <brief>` in the
-  TUI instead of the raw `ImplementAndJudge(4 args: …)` argument dump.
+## 0.53.0 (2026-06-23)
+
+- **GPT/ChatGPT session re-authentication crash fixed.** A fatal "Could not
+  resolve authentication method" error when a session token is invalidated
+  mid-session (e.g. the OAuth refresh token was rotated by signing in on
+  another machine) now surfaces as a typed 401 that routes into the standard
+  re-authentication path — prompting `/login` rather than dumping a traceback.
+- **`ImplementAndJudge` renders as `Implement & Judge — <brief>` in the TUI.**
+  The chain no longer shows the raw `ImplementAndJudge(4 args: …)` argument
+  dump; it now displays a clean `Implement & Judge — <brief>` label matching
+  the style of other named subagent invocations.
 
 ## 0.52.0 (2026-06-23)
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,12 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.52.0
+## 🆕 What's New in 0.53.0
 
-- **Model-aware thinking levels.** The thinking selector and Shift+Tab cycle now scope reasoning effort to what the active GPT-5-family model accepts; unsupported persisted levels are clamped before the API call.
-- **Cleaner diff cards.** Diff syntax highlighting no longer paints an opaque code-theme background over green/red row tints — tints show through on every terminal.
-- **Truecolor in VS Code terminals.** Integrated terminals reporting `TERM_PROGRAM=vscode` (and forks) are promoted to truecolor so diff tints don't fall back to 16-color mode.
-- **No duplicate welcome banner on reload.** Same-session reloads (`/model`, `/theme`, `/thinking`, …) keep the existing banner instead of stacking a second splash.
-- **Update notice moved to footer.** The persistent "Restart to apply" / "Update available" line renders below the status/clock row, clear of the input box.
-- **Safer Homebrew self-upgrades.** Silent `brew upgrade` runs with cleanup/auto-update disabled so the in-use Cellar version isn't deleted mid-session.
+- **GPT/ChatGPT re-auth crash fixed.** A "Could not resolve authentication method" crash when a session token is invalidated mid-session (OAuth refresh rotated on another machine) now routes into the standard `/login` re-authentication path instead of dumping a traceback.
+- **Cleaner `ImplementAndJudge` label in the TUI.** The chain now shows `Implement & Judge — <brief>` instead of the raw `ImplementAndJudge(4 args: …)` argument dump.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.52.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.53.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -149,7 +145,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.52.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.53.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -177,7 +173,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.52.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.53.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -188,13 +184,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.52.0.exe
+.\PythinkerSetup-0.53.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.52.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.53.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -252,26 +248,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.52.0_amd64.deb
+sudo dpkg -i pythinker-code_0.53.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.52.0_arm64.deb
+sudo dpkg -i pythinker-code_0.53.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.52.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.53.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.52.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.53.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.52.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.53.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.52.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.52.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.53.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.53.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -280,8 +276,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.52.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.52.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.53.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.53.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.52.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.53.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.53.0 (2026-06-23)
+
+No breaking changes. This release is compatible with 0.52.0 user configuration, native installs, and session data.
+
 ## 0.52.0 (2026-06-23)
 
 ## 0.51.0 (2026-06-22)

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,18 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.53.0 (2026-06-23)
+
+- **GPT/ChatGPT session re-authentication crash fixed.** A fatal "Could not
+  resolve authentication method" error when a session token is invalidated
+  mid-session (e.g. the OAuth refresh token was rotated by signing in on
+  another machine) now surfaces as a typed 401 that routes into the standard
+  re-authentication path — prompting `/login` rather than dumping a traceback.
+- **`ImplementAndJudge` renders as `Implement & Judge — <brief>` in the TUI.**
+  The chain no longer shows the raw `ImplementAndJudge(4 args: …)` argument
+  dump; it now displays a clean `Implement & Judge — <brief>` label matching
+  the style of other named subagent invocations.
+
 ## 0.52.0 (2026-06-23)
 
 - **`InvalidToolError` now names the failing tool and the reason.** A bad

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code_0.52.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code_0.52.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.52.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.52.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code_0.53.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code_0.53.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.53.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.53.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.52.0/pythinker-code-0.52.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.52.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.52.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.53.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.53.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.52.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.53.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -41,8 +41,8 @@ bash packages/linux-installer/build.sh 0.51.0
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.52.0_amd64.deb`
-- `pythinker-code-0.52.0.x86_64.rpm`
+- `pythinker-code_0.53.0_amd64.deb`
+- `pythinker-code-0.53.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.52.0"
+version = "0.53.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.52.0"
+version = "0.53.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release 0.53.0

### Changes in this release

- **GPT/ChatGPT session re-authentication crash fixed.** A fatal "Could not resolve authentication method" error when a session token is invalidated mid-session (e.g. the OAuth refresh token was rotated by signing in on another machine) now surfaces as a typed 401 that routes into the standard re-authentication path — prompting `/login` rather than dumping a traceback.
- **`ImplementAndJudge` renders as `Implement & Judge — <brief>` in the TUI.** The chain no longer shows the raw `ImplementAndJudge(4 args: …)` argument dump; it displays a clean `Implement & Judge — <brief>` label matching the style of other named subagent invocations.

### Files changed

- `pyproject.toml` + `uv.lock` — version bump `0.52.0` → `0.53.0`
- `CHANGELOG.md` — promote Unreleased → `## 0.53.0 (2026-06-23)`
- `docs/en/release-notes/changelog.md` — mirror
- `docs/en/release-notes/breaking-changes.md` — add `## 0.53.0` (no breaking changes)
- `README.md` — update What's New section + all asset version refs
- `docs/en/guides/getting-started.md` + `packages/linux-installer/README.md` — version refs