### PR TITLE
chore(release): prepare 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,17 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
-- Add a built-in `Workflow` tool that runs a deterministic Python script orchestrating
-  multiple subagents via `agent()`, `parallel()`, and `pipeline()`, with live progress,
-  structured-schema output, and one-shot approval.
+## 0.54.0 (2026-06-30)
+
+- **New `Workflow` tool for deterministic multi-agent orchestration.** The default
+  agent can now author and run a JavaScript-like script that fans work out across
+  subagents with `agent()`, `parallel()`, and `pipeline()` primitives, then
+  synthesizes the results — instead of manually chaining one-off subagent calls.
+  Runs stream live progress (phases, per-agent status) to the TUI, support
+  structured-schema output per agent call, enforce an optional token budget, and
+  require a single up-front approval rather than one per spawned subagent.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.54.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.53.0 (2026-06-23)
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.53.0
+## 🆕 What's New in 0.54.0
 
-- **GPT/ChatGPT re-auth crash fixed.** A "Could not resolve authentication method" crash when a session token is invalidated mid-session (OAuth refresh rotated on another machine) now routes into the standard `/login` re-authentication path instead of dumping a traceback.
-- **Cleaner `ImplementAndJudge` label in the TUI.** The chain now shows `Implement & Judge — <brief>` instead of the raw `ImplementAndJudge(4 args: …)` argument dump.
+- **New `Workflow` tool for deterministic multi-agent orchestration.** The default agent can author and run a script that fans work out across subagents with `agent()`, `parallel()`, and `pipeline()`, with live progress, structured-schema output, an optional token budget, and a single up-front approval.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.53.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.54.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -145,7 +144,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.53.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.54.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -173,7 +172,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.53.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.54.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -184,13 +183,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.53.0.exe
+.\PythinkerSetup-0.54.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.53.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.54.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -248,26 +247,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.53.0_amd64.deb
+sudo dpkg -i pythinker-code_0.54.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.53.0_arm64.deb
+sudo dpkg -i pythinker-code_0.54.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.53.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code-0.54.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code-0.54.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.54.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.53.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.54.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.53.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.54.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.53.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.53.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code-0.54.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code-0.54.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.54.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.54.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -276,8 +275,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.53.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.53.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.54.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.54.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.53.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.54.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.54.0 (2026-06-30)
+
+No breaking changes. This release is compatible with 0.53.0 user configuration, native installs, and session data.
+
 ## 0.53.0 (2026-06-23)
 
 No breaking changes. This release is compatible with 0.52.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,18 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.54.0 (2026-06-30)
+
+- **New `Workflow` tool for deterministic multi-agent orchestration.** The default
+  agent can now author and run a JavaScript-like script that fans work out across
+  subagents with `agent()`, `parallel()`, and `pipeline()` primitives, then
+  synthesizes the results — instead of manually chaining one-off subagent calls.
+  Runs stream live progress (phases, per-agent status) to the TUI, support
+  structured-schema output per agent call, enforce an optional token budget, and
+  require a single up-front approval rather than one per spawned subagent.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.54.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+
 ## 0.53.0 (2026-06-23)
 
 - **GPT/ChatGPT session re-authentication crash fixed.** A fatal "Could not

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code_0.53.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code_0.53.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.53.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.53.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code_0.54.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code_0.54.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.54.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.54.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.53.0/pythinker-code-0.53.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.53.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.53.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code-0.54.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.54.0/pythinker-code-0.54.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.54.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.54.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.53.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.54.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -41,8 +41,8 @@ bash packages/linux-installer/build.sh 0.51.0
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.53.0_amd64.deb`
-- `pythinker-code-0.53.0.x86_64.rpm`
+- `pythinker-code_0.54.0_amd64.deb`
+- `pythinker-code-0.54.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -36,7 +36,7 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.51.0
+bash packages/linux-installer/build.sh 0.54.0
 ```
 
 Outputs to `dist/`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.53.0"
+version = "0.54.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.53.0"
+version = "0.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- Releases the `Workflow` tool for deterministic multi-agent orchestration (merged in #186) as 0.54.0.
- Bumps `pyproject.toml`/`uv.lock` to 0.54.0, moves the Unreleased changelog entry into a dated `## 0.54.0` section (root + docs mirror), and adds a no-breaking-changes entry to `breaking-changes.md`.
- Updates README "What's New" and all version-pinned install/download examples (Windows installer, deb/rpm filenames and URLs) from 0.53.0 to 0.54.0.

## Test plan
- [x] `scripts/check_version_tag.py` confirms `pyproject.toml` matches 0.54.0
- [x] README contains the `What's New in 0.54.0` heading and `pythinker-code==0.54.0` upgrade snippet
- [x] `CHANGELOG.md` contains a `## 0.54.0 (...)` heading
- [x] `scripts/check_pythinker_dependency_versions.py` passes
- [x] `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py` — 17 passed
- [x] `git grep -nF "0.53.0"` shows only historical changelog entries remaining
- [x] `make build-web build-dashboard` rebuilt so local UI bundles don't show a stale fallback version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Workflow** tool for deterministic multi-agent orchestration, including live streaming progress, structured per-agent outputs, optional token budget controls, and a single up-front approval step.

* **Documentation**
  * Updated release notes and installation/upgrade instructions to **0.54.0** across Windows and Linux, including revised installer filenames, package URLs, and checksum verification steps.

* **Chores**
  * Bumped the project version to **0.54.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->