### PR TITLE
chore(release): prepare 0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,24 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
-- Fix the Windows shell UI going blank mid-session (transcript and input box
-  disappearing until terminal restart): child processes no longer attach to the
-  interactive console (`CREATE_NO_WINDOW` on Shell-tool, background-task, and
-  `!` command spawns), and the prompt renderer now forces an absolute repaint
-  after terminal resizes and failed scrollback handoffs instead of diffing
-  against a stale frame.
-- Fix Workflow progress rendering duplicating agents truncated by the per-phase
-  display cap, close leaked `agent()` coroutines when `parallel()` rejects its
-  arguments, and add a 1000-agent lifetime backstop against runaway workflow loops.
-- Fix stale update-success notices so restarting into an older Homebrew install
-  shows `/update` again instead of a permanent "Restart to apply" banner.
+## 0.56.0 (2026-07-02)
+
+- **Windows shell UI recovers from mid-session console blanking.** The TUI's
+  transcript and input box could go blank mid-session until a terminal restart;
+  child processes spawned by the Shell tool, background tasks, and `!` commands
+  no longer attach to the interactive console (`CREATE_NO_WINDOW`), and the
+  prompt renderer now forces an absolute repaint after terminal resizes and
+  failed scrollback handoffs instead of diffing against a stale frame.
+- **Workflow progress rendering and lifecycle fixes.** Progress display no
+  longer duplicates agents once truncated by the per-phase display cap,
+  `agent()` coroutines are no longer leaked when `parallel()` rejects its
+  arguments, and a 1000-agent lifetime backstop now guards against runaway
+  workflow loops.
+- **Stale update-success notice cleared after downgrading.** Restarting into
+  an older Homebrew install no longer leaves a permanent "Restart to apply"
+  banner — the `/update` command surfaces again as expected.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.56.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.55.0 (2026-06-30)
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.55.0
+## 🆕 What's New in 0.56.0
 
-- **Local-model reliability fixes for compaction, Qwen3 reasoning, and stuck loops.** Capped context-compaction summary output so a slow/degenerate local model completion can't hang the soul loop, switched self-hosted `openai_legacy` endpoints (llama.cpp/vLLM/LM Studio) to Qwen3.x's binary `enable_thinking` toggle instead of a tiered `reasoning_effort` value, and added a second stuck-loop backstop that catches consecutive identical tool calls even when each reports success.
+- **Windows shell UI recovers from mid-session console blanking.** Child processes spawned by the Shell tool, background tasks, and `!` commands no longer attach to the interactive console, and the prompt renderer forces an absolute repaint after terminal resizes and failed scrollback handoffs instead of diffing against a stale frame.
+- **Workflow progress rendering and lifecycle fixes.** Progress display no longer duplicates agents truncated by the per-phase display cap, leaked `agent()` coroutines are closed when `parallel()` rejects its arguments, and a 1000-agent lifetime backstop now guards against runaway workflow loops.
+- **Stale update-success notice cleared after downgrading.** Restarting into an older Homebrew install no longer leaves a permanent "Restart to apply" banner.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.55.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.56.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -144,7 +146,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.55.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.56.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -172,7 +174,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.55.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.56.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -183,13 +185,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.55.0.exe
+.\PythinkerSetup-0.56.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.55.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.56.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -247,26 +249,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.55.0_amd64.deb
+sudo dpkg -i pythinker-code_0.56.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.55.0_arm64.deb
+sudo dpkg -i pythinker-code_0.56.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code-0.55.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code-0.55.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.55.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.56.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.55.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.56.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.55.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.56.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code-0.55.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code-0.55.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.55.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.55.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.56.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.56.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -275,8 +277,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.55.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.55.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.56.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.56.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.55.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.56.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.56.0 (2026-07-02)
+
+No breaking changes. This release is compatible with 0.55.0 user configuration, native installs, and session data.
+
 ## 0.55.0 (2026-06-30)
 
 No breaking changes. This release is compatible with 0.54.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,25 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.56.0 (2026-07-02)
+
+- **Windows shell UI recovers from mid-session console blanking.** The TUI's
+  transcript and input box could go blank mid-session until a terminal restart;
+  child processes spawned by the Shell tool, background tasks, and `!` commands
+  no longer attach to the interactive console (`CREATE_NO_WINDOW`), and the
+  prompt renderer now forces an absolute repaint after terminal resizes and
+  failed scrollback handoffs instead of diffing against a stale frame.
+- **Workflow progress rendering and lifecycle fixes.** Progress display no
+  longer duplicates agents once truncated by the per-phase display cap,
+  `agent()` coroutines are no longer leaked when `parallel()` rejects its
+  arguments, and a 1000-agent lifetime backstop now guards against runaway
+  workflow loops.
+- **Stale update-success notice cleared after downgrading.** Restarting into
+  an older Homebrew install no longer leaves a permanent "Restart to apply"
+  banner — the `/update` command surfaces again as expected.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.56.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+
 ## 0.55.0 (2026-06-30)
 
 - **Local-model reliability fixes for compaction, Qwen3 reasoning, and stuck loops.**

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code_0.55.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code_0.55.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.55.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.55.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code_0.56.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code_0.56.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.56.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.56.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code-0.55.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.55.0/pythinker-code-0.55.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.55.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.55.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.56.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.56.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.55.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.56.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,13 +36,13 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.55.0
+bash packages/linux-installer/build.sh 0.56.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.55.0_amd64.deb`
-- `pythinker-code-0.55.0.x86_64.rpm`
+- `pythinker-code_0.56.0_amd64.deb`
+- `pythinker-code-0.56.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.55.0"
+version = "0.56.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2515,7 +2515,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.55.0"
+version = "0.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- Bump version 0.55.0 → 0.56.0 across pyproject.toml, uv.lock, README, docs, and installer references
- Consume `## Unreleased` into a new `## 0.56.0 (2026-07-02)` CHANGELOG section (Windows shell UI blanking recovery, Workflow progress/lifecycle fixes, stale update-success notice fix) and sync into docs/en/release-notes/changelog.md
- Add 0.56.0 entry to docs/en/release-notes/breaking-changes.md (no breaking changes)

## Test plan
- [x] `scripts/check_version_tag.py` — pyproject matches 0.56.0
- [x] README contains "What's New in 0.56.0" and `pythinker-code==0.56.0` upgrade snippet
- [x] CHANGELOG.md has `## 0.56.0 (` heading
- [x] `scripts/check_pythinker_dependency_versions.py` — workspace package versions match
- [x] `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py` — 17 passed
- [x] `make build-web build-dashboard` run locally to refresh bundled UI version fallback
- [x] `git grep -F "0.55.0"` outside CHANGELOG/history — no stray references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version **0.56.0** with updated notes covering improved Windows shell UI recovery, smoother workflow rendering/lifecycle behavior, and removal of stale update-success notices after downgrades.
* **Documentation**
  * Updated installation and upgrade instructions to match **0.56.0** across Windows, Linux, and package download guidance.
  * Refreshed release references and checksum links for the latest installers.
* **Chores**
  * Bumped the published package version to **0.56.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->