### PR TITLE
chore(release): prepare 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,51 +15,31 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
-- Show active subagent tool work in the pinned TUI status tail instead of
-  leaving long foreground agent runs on the generic composing spinner.
-- Keep the TUI prompt bar visible while an agent turn is starting so the
-  empty composer does not disappear during lazy-load frames.
-- Ported the running agent TUI toward Pi's stable diff-rendered scene model so streamed output keeps the input card visible without prompt jumps.
-- Added publishability-focused benchmark comparison planning for multi-model
-  runs, activity metrics, exportable reports, and safe online source discovery.
-- Added an experimental Focus TUI mode for active agent turns, keeping the composer pinned, hiding file activity by default, and rendering live output without terminal scrollback jumps.
-- Stream file write/edit activity in a compact live shelf so changed files update in place during agent runs instead of adding noisy terminal rows.
-- Hardened `/benchmark` local fixture runs: task `max_steps` now caps the
-  underlying agent turn, and `/benchmark:swe` requires `--trusted-dataset true`
-  because trusted local fixture datasets execute verification commands.
-- Hardened benchmark and active-skill security edges: SWE verification commands
-  are shape-validated before execution, benchmark discovery requires explicit
-  network opt-in, benchmark run IDs avoid clock collisions, runtime overrides
-  restore after setup failures, and active-skill deactivation persistence
-  failures are surfaced instead of swallowed.
-- Strengthened the bundled `pythinker-core` benchmark suite with edge-case
-  fixtures for atomic rollback, iterable de-duplication, explicit falsey
-  metadata values, and safe path joins across absolute, sibling-prefix, parent,
-  and symlink escapes.
-
-- Keep the terminal input composer pinned to the bottom during agent runs with a fullscreen prompt mode to reduce TUI flicker.
-
-- Explicitly invoked skills now remain active across later turns through a
-  compact reminder, and can be cleared with a named stop request or "normal mode".
+## 0.57.0 (2026-07-05)
 
 - **No more ghost/duplicate input prompt while the agent works.** After
-  submitting a prompt, the editable input row is no longer fossilized above the
-  stream as a second, ghostly prompt. The top border stays visible while the
-  pre-attach race frame still collapses before the running-prompt delegate
-  exists, preventing prompt chrome from fossilizing above the spinner. Once the
-  running frame owns the prompt, the `❯` marker stays visible while only the
-  editable buffer is hidden until the first scrollback commit, avoiding the
-  collapsed one-line card under the lazy-load spinner; the full editable row
-  remains below the live stream so you can still see where to steer.
+  submitting a prompt, the input card no longer fossilizes above the stream as
+  a second, ghostly prompt. The prompt bar and top border now stay visible
+  through turn-start and lazy-load frames, and running-agent output renders
+  through a stable diff-rendered scene (ported from Pi) so the input card no
+  longer jumps. An experimental Focus TUI mode (`tui.focus_mode`) pins the
+  composer and hides file activity behind a compact live shelf for a cleaner
+  fullscreen view, and active subagent tool work now surfaces in the pinned
+  status tail instead of a generic composing spinner.
+- **Added a native `/benchmark` command suite.** Run deterministic local
+  Pythinker model evaluations with bundled smoke tasks and SWE-style JSONL
+  tasks (`/benchmark:swe`), plus compare, export, and source-discovery
+  subcommands that produce replayable artifacts, activity metrics, and
+  branded markdown reports.
+- **Hardened benchmark and skill security edges.** SWE verification commands
+  are shape-validated before execution, benchmark discovery requires explicit
+  network opt-in, run IDs avoid clock collisions, runtime overrides restore
+  after setup failures, and active-skill deactivation failures now surface
+  instead of being swallowed. Explicitly invoked skills stay active across
+  later turns through a compact reminder until stopped by name or
+  "normal mode".
 
-- Added native `/benchmark` slash command for deterministic local Pythinker
-  model evaluation with bundled smoke tasks, replayable artifacts, and branded
-  markdown reports.
-- Expanded `/benchmark start` to use a richer default core suite, isolate file
-  edits through the active toolset workspace override, and exclude generated
-  verification caches from changed-file reports.
-- Added `/benchmark:swe` for native SWE-style JSONL benchmark tasks that run
-  through Pythinker's existing model, tool, verification, and artifact path.
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.57.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.56.0 (2026-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ GitHub Releases page; `0.8.0` is the new starting line.
   status tail instead of a generic composing spinner.
 - **Added a native `/benchmark` command suite.** Run deterministic local
   Pythinker model evaluations with bundled smoke tasks and SWE-style JSONL
-  tasks (`/benchmark:swe`), plus compare, export, and source-discovery
-  subcommands that produce replayable artifacts, activity metrics, and
-  branded markdown reports.
+  tasks (`/benchmark:swe`), plus `/benchmark compare`, `/benchmark export`,
+  and `/benchmark discover` actions that produce replayable artifacts,
+  activity metrics, and branded markdown reports.
 - **Hardened benchmark and skill security edges.** SWE verification commands
   are shape-validated before execution, benchmark discovery requires explicit
   network opt-in, run IDs avoid clock collisions, runtime overrides restore

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 ## 🆕 What's New in 0.57.0
 
 - **No more ghost/duplicate input prompt while the agent works.** The input card no longer fossilizes above the stream as a second, ghostly prompt; the prompt bar and top border stay visible through turn-start and lazy-load frames; running-agent output renders through a stable diff-rendered scene (ported from Pi); and an experimental Focus TUI mode (`tui.focus_mode`) pins the composer and hides file activity behind a compact live shelf.
-- **Added a native `/benchmark` command suite.** Run deterministic local Pythinker model evaluations with bundled smoke tasks and SWE-style JSONL tasks (`/benchmark:swe`), plus compare, export, and source-discovery subcommands with replayable artifacts and branded markdown reports.
+- **Added a native `/benchmark` command suite.** Run deterministic local Pythinker model evaluations with bundled smoke tasks and SWE-style JSONL tasks (`/benchmark:swe`), plus `/benchmark compare`, `/benchmark export`, and `/benchmark discover` actions with replayable artifacts and branded markdown reports.
 - **Hardened benchmark and skill security edges.** SWE verification commands are shape-validated before execution, benchmark discovery requires explicit network opt-in, and active-skill deactivation failures now surface instead of being swallowed.
 
 Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.57.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
@@ -190,10 +190,11 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.57.0.exe` is a signed* Inno Setup wizard. Installs per-user
-into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
-PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
-the change. **No UAC prompt.**
+`PythinkerSetup-0.57.0.exe` is an Inno Setup wizard. Release builds are signed
+when Authenticode secrets are configured in CI; otherwise the installer ships
+unsigned. Installs per-user into `%LOCALAPPDATA%\Programs\Pythinker`, registers
+`pythinker` on your user PATH (`HKCU\Environment`), broadcasts
+`WM_SETTINGCHANGE` so new shells see the change. **No UAC prompt.**
 
 ```powershell
 # One-line install (downloads the native .exe, verifies SHA-256, runs per-user)
@@ -211,14 +212,14 @@ pythinker --version
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
-the newest installer, verifies SHA-256, and launches the signed Inno installer
+the newest installer, verifies SHA-256, and launches the Inno installer
 with visible progress (`/SILENT /NORESTART /CURRENTUSER /CLOSEAPPLICATIONS /NORESTARTAPPLICATIONS`).
 
 **Uninstall:** Apps & Features → *Pythinker Code* → Uninstall reverts both
 the files and the PATH edit.
 
-> 🛡 **First-launch SmartScreen warning** — \*until the Authenticode cert is
-> provisioned in CI, the installer ships unsigned and Windows shows
+> 🛡 **First-launch SmartScreen warning** — Until Authenticode secrets are
+> configured in CI for a release, the installer ships unsigned and Windows shows
 > *"Windows protected your PC."* Click **More info → Run anyway**. Use the
 > published `.sha256` as your integrity check until signing comes online.
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.56.0
+## 🆕 What's New in 0.57.0
 
-- **Windows shell UI recovers from mid-session console blanking.** Child processes spawned by the Shell tool, background tasks, and `!` commands no longer attach to the interactive console, and the prompt renderer forces an absolute repaint after terminal resizes and failed scrollback handoffs instead of diffing against a stale frame.
-- **Workflow progress rendering and lifecycle fixes.** Progress display no longer duplicates agents truncated by the per-phase display cap, leaked `agent()` coroutines are closed when `parallel()` rejects its arguments, and a 1000-agent lifetime backstop now guards against runaway workflow loops.
-- **Stale update-success notice cleared after downgrading.** Restarting into an older Homebrew install no longer leaves a permanent "Restart to apply" banner.
+- **No more ghost/duplicate input prompt while the agent works.** The input card no longer fossilizes above the stream as a second, ghostly prompt; the prompt bar and top border stay visible through turn-start and lazy-load frames; running-agent output renders through a stable diff-rendered scene (ported from Pi); and an experimental Focus TUI mode (`tui.focus_mode`) pins the composer and hides file activity behind a compact live shelf.
+- **Added a native `/benchmark` command suite.** Run deterministic local Pythinker model evaluations with bundled smoke tasks and SWE-style JSONL tasks (`/benchmark:swe`), plus compare, export, and source-discovery subcommands with replayable artifacts and branded markdown reports.
+- **Hardened benchmark and skill security edges.** SWE verification commands are shape-validated before execution, benchmark discovery requires explicit network opt-in, and active-skill deactivation failures now surface instead of being swallowed.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.56.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.57.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -162,7 +162,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.56.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.57.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -190,7 +190,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.56.0.exe` is a signed* Inno Setup wizard. Installs per-user
+`PythinkerSetup-0.57.0.exe` is a signed* Inno Setup wizard. Installs per-user
 into `%LOCALAPPDATA%\Programs\Pythinker`, registers `pythinker` on your user
 PATH (`HKCU\Environment`), broadcasts `WM_SETTINGCHANGE` so new shells see
 the change. **No UAC prompt.**
@@ -201,13 +201,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.56.0.exe
+.\PythinkerSetup-0.57.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.56.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.57.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -265,26 +265,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.56.0_amd64.deb
+sudo dpkg -i pythinker-code_0.57.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.56.0_arm64.deb
+sudo dpkg -i pythinker-code_0.57.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.56.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code-0.57.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code-0.57.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.57.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.56.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.57.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.56.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.57.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.56.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.56.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code-0.57.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code-0.57.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.57.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.57.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -293,8 +293,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.56.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.56.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.57.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.57.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.56.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.57.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.57.0 (2026-07-05)
+
+No breaking changes. This release is compatible with 0.56.0 user configuration, native installs, and session data.
+
 ## 0.56.0 (2026-07-02)
 
 No breaking changes. This release is compatible with 0.55.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -30,9 +30,9 @@ GitHub Releases page; `0.8.0` is the new starting line.
   status tail instead of a generic composing spinner.
 - **Added a native `/benchmark` command suite.** Run deterministic local
   Pythinker model evaluations with bundled smoke tasks and SWE-style JSONL
-  tasks (`/benchmark:swe`), plus compare, export, and source-discovery
-  subcommands that produce replayable artifacts, activity metrics, and
-  branded markdown reports.
+  tasks (`/benchmark:swe`), plus `/benchmark compare`, `/benchmark export`,
+  and `/benchmark discover` actions that produce replayable artifacts,
+  activity metrics, and branded markdown reports.
 - **Hardened benchmark and skill security edges.** SWE verification commands
   are shape-validated before execution, benchmark discovery requires explicit
   network opt-in, run IDs avoid clock collisions, runtime overrides restore

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,40 +17,31 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
-- Added publishability-focused benchmark comparison planning for multi-model
-  runs, activity metrics, exportable reports, and safe online source discovery.
-- Stream file write/edit activity in a compact live shelf so changed files update in place during agent runs instead of adding noisy terminal rows.
-- Hardened `/benchmark` local fixture runs: task `max_steps` now caps the
-  underlying agent turn, and `/benchmark:swe` requires `--trusted-dataset true`
-  because trusted local fixture datasets execute verification commands.
-- Strengthened the bundled `pythinker-core` benchmark suite with edge-case
-  fixtures for atomic rollback, iterable de-duplication, explicit falsey
-  metadata values, and safe path joins across absolute, sibling-prefix, parent,
-  and symlink escapes.
-
-- Keep the terminal input composer pinned to the bottom during agent runs with a fullscreen prompt mode to reduce TUI flicker.
-
-- Explicitly invoked skills now remain active across later turns through a
-  compact reminder, and can be cleared with a named stop request or "normal mode".
+## 0.57.0 (2026-07-05)
 
 - **No more ghost/duplicate input prompt while the agent works.** After
-  submitting a prompt, the editable input row is no longer fossilized above the
-  stream as a second, ghostly prompt. The top border stays visible while the
-  pre-attach race frame still collapses before the running-prompt delegate
-  exists, preventing prompt chrome from fossilizing above the spinner. Once the
-  running frame owns the prompt, the `❯` marker stays visible while only the
-  editable buffer is hidden until the first scrollback commit, avoiding the
-  collapsed one-line card under the lazy-load spinner; the full editable row
-  remains below the live stream so you can still see where to steer.
+  submitting a prompt, the input card no longer fossilizes above the stream as
+  a second, ghostly prompt. The prompt bar and top border now stay visible
+  through turn-start and lazy-load frames, and running-agent output renders
+  through a stable diff-rendered scene (ported from Pi) so the input card no
+  longer jumps. An experimental Focus TUI mode (`tui.focus_mode`) pins the
+  composer and hides file activity behind a compact live shelf for a cleaner
+  fullscreen view, and active subagent tool work now surfaces in the pinned
+  status tail instead of a generic composing spinner.
+- **Added a native `/benchmark` command suite.** Run deterministic local
+  Pythinker model evaluations with bundled smoke tasks and SWE-style JSONL
+  tasks (`/benchmark:swe`), plus compare, export, and source-discovery
+  subcommands that produce replayable artifacts, activity metrics, and
+  branded markdown reports.
+- **Hardened benchmark and skill security edges.** SWE verification commands
+  are shape-validated before execution, benchmark discovery requires explicit
+  network opt-in, run IDs avoid clock collisions, runtime overrides restore
+  after setup failures, and active-skill deactivation failures now surface
+  instead of being swallowed. Explicitly invoked skills stay active across
+  later turns through a compact reminder until stopped by name or
+  "normal mode".
 
-- Added native `/benchmark` slash command for deterministic local Pythinker
-  model evaluation with bundled smoke tasks, replayable artifacts, and branded
-  markdown reports.
-- Expanded `/benchmark start` to use a richer default core suite, isolate file
-  edits through the active toolset workspace override, and exclude generated
-  verification caches from changed-file reports.
-- Added `/benchmark:swe` for native SWE-style JSONL benchmark tasks that run
-  through Pythinker's existing model, tool, verification, and artifact path.
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.57.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.56.0 (2026-07-02)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code_0.56.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code_0.56.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.56.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.56.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code_0.57.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code_0.57.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.57.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.57.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.56.0/pythinker-code-0.56.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.56.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.56.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code-0.57.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.57.0/pythinker-code-0.57.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.57.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.57.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.56.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.57.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,13 +36,13 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.56.0
+bash packages/linux-installer/build.sh 0.57.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.56.0_amd64.deb`
-- `pythinker-code-0.56.0.x86_64.rpm`
+- `pythinker-code_0.57.0_amd64.deb`
+- `pythinker-code-0.57.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.56.0"
+version = "0.57.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2527,7 +2527,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.56.0"
+version = "0.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Related Issue

N/A - release preparation PR.

## Description

- Bump version 0.56.0 -> 0.57.0 across pyproject.toml, uv.lock, README, docs, and installer references.
- Consume `## Unreleased` into a new `## 0.57.0 (2026-07-05)` CHANGELOG section covering the ghost input-prompt/TUI stability fixes, native `/benchmark` command suite, and benchmark/skill security hardening.
- Sync the release notes into `docs/en/release-notes/changelog.md` and add the 0.57.0 no-breaking-changes entry.
- Resolve CodeRabbit release-note comments by aligning `/benchmark discover` and Windows installer signing wording with the implemented behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

Note: `make gen-changelog` and `make gen-docs` were invoked and exited 0, but the current local Pythinker command reported `Unknown slash command` for `/skill:gen-changelog` and `/skill:gen-docs`; `npm run build` in `docs/` performed the actual changelog sync and docs build validation.

## Test plan

- [x] `scripts/check_version_tag.py` — pyproject matches 0.57.0.
- [x] README contains "What's New in 0.57.0" and `pythinker-code==0.57.0` upgrade snippet.
- [x] CHANGELOG.md has `## 0.57.0 (` heading.
- [x] `scripts/check_pythinker_dependency_versions.py` — workspace package versions match.
- [x] `pytest tests/test_installation_docs.py tests/test_homebrew_formula.py` — 17 passed.
- [x] `make build-web build-dashboard` run locally to refresh bundled UI version fallback.
- [x] `git grep -F "0.56.0"` outside CHANGELOG/history — no stray references.
- [x] `npm run build` from `docs/` — docs sync and VitePress build passed.
- [x] `git diff --check` — whitespace check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native `/benchmark` command with local, deterministic evaluation and generated artifacts, metrics, and reports.
  * Improved the TUI experience by removing duplicate input prompts and refining active-work status display.

* **Bug Fixes**
  * Hardened benchmark and skill-handling behavior with safer validation, better recovery after setup issues, and clearer failure reporting.

* **Documentation**
  * Updated release notes and installation guides for version 0.57.0 across Windows and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->