### PR TITLE
chore(release): prepare 0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.59.0 (2026-07-17)
+
 - **Reviewer subagents now receive deterministic Git scopes.** Structured automatic,
   uncommitted, base, and commit targets resolve to full commit anchors before dispatch, reject
   invalid or empty scopes explicitly, and keep repository metadata isolated from instructions
@@ -22,6 +24,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **Parallel streamed tool calls are now correlated safely.** Interleaved argument chunks stay attached to their indexed calls, malformed or truncated call streams stop before tool execution, and failed attempts are not retried after output has already been shown.
 - **Provider compatibility and Z.AI routing are now explicit.** Immutable compatibility profiles keep request-format quirks behind the chat-provider boundary, while independent Z.AI Coding Plan and API login routes use separate credentials, endpoints, model identities, catalog refresh, logout, and usage/rate-limit state. Curated GLM requests now apply exact context/output limits, thinking controls, reasoning replay, and tool-stream support without activating for local or unknown models.
 - **Tool execution is now supervised as a terminal batch.** A private execution engine preserves the Toolset registry and legacy per-call API while centralizing ordered results, deduplication, callbacks, and batch summaries; cancellation is bounded, late work stays owned, and new batches fail closed until timed-out cleanup drains.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.59.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.58.0 (2026-07-11)
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.58.0
+## 🆕 What's New in 0.59.0
 
-- **Agent core deepened with an observable request-assembly path.** Provider handoff, prompt ordering, and context persistence now run through explicit compatibility contracts, conversation history updates are transactional (atomic replacement with cancellation and rollback), and agent/skill definitions resolve through one source-aware catalogue instead of scattered lookups.
-- **Agent-spec loading is more defensive and truthful.** Subagent `path`, `extend`, and `system_prompt_path` references that resolve outside their spec's directory are now rejected instead of loaded, and malformed frontmatter parsing errors are no longer misreported as harmless skips.
-- **Thinking and subagent activity render cleanly in the terminal.** Live reasoning previews render complete Markdown without exposing stray HTML comments, and activity-tree rows stay visually stable during long-running turns.
+- **Explicit Z.AI compatibility routes.** Independent Z.AI Coding Plan and API login routes now use separate credentials, endpoints, model identities, catalog refresh, logout, and usage/rate-limit state, with immutable compatibility profiles keeping request-format quirks behind the chat-provider boundary.
+- **Streamed tool calls are correlated safely.** Interleaved argument chunks stay attached to their indexed calls, malformed or truncated call streams stop before tool execution, and failed attempts are not retried after output has already been shown.
+- **Deterministic reviewer scopes and supervised tool batches.** Reviewer subagents receive fully resolved Git commit anchors with invalid or empty scopes rejected explicitly, and tool execution runs through a supervised batch engine with ordered results, bounded cancellation, and fail-closed new batches until cleanup drains.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.58.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.59.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -162,7 +162,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.58.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.59.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -190,7 +190,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.58.0.exe` is an Inno Setup wizard. Release builds are signed
+`PythinkerSetup-0.59.0.exe` is an Inno Setup wizard. Release builds are signed
 when Authenticode secrets are configured in CI; otherwise the installer ships
 unsigned. Installs per-user into `%LOCALAPPDATA%\Programs\Pythinker`, registers
 `pythinker` on your user PATH (`HKCU\Environment`), broadcasts
@@ -202,13 +202,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.58.0.exe
+.\PythinkerSetup-0.59.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.58.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.59.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -266,26 +266,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.58.0_amd64.deb
+sudo dpkg -i pythinker-code_0.59.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.58.0_arm64.deb
+sudo dpkg -i pythinker-code_0.59.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code-0.58.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code-0.58.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.58.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code-0.59.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code-0.59.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.59.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.58.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.59.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.58.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.59.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code-0.58.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code-0.58.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.58.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.58.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code-0.59.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code-0.59.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.59.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.59.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -294,8 +294,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.58.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.58.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.59.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.59.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.58.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.59.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,10 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.59.0 (2026-07-17)
+
+No breaking changes. This release is compatible with 0.58.0 user configuration, native installs, and session data.
+
 ## 0.58.0 (2026-07-11)
 
 No breaking changes. This release is compatible with 0.57.0 user configuration, native installs, and session data.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.59.0 (2026-07-17)
+
 - **Reviewer subagents now receive deterministic Git scopes.** Structured automatic,
   uncommitted, base, and commit targets resolve to full commit anchors before dispatch, reject
   invalid or empty scopes explicitly, and keep repository metadata isolated from instructions
@@ -24,6 +26,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - **Parallel streamed tool calls are now correlated safely.** Interleaved argument chunks stay attached to their indexed calls, malformed or truncated call streams stop before tool execution, and failed attempts are not retried after output has already been shown.
 - **Provider compatibility and Z.AI routing are now explicit.** Immutable compatibility profiles keep request-format quirks behind the chat-provider boundary, while independent Z.AI Coding Plan and API login routes use separate credentials, endpoints, model identities, catalog refresh, logout, and usage/rate-limit state. Curated GLM requests now apply exact context/output limits, thinking controls, reasoning replay, and tool-stream support without activating for local or unknown models.
 - **Tool execution is now supervised as a terminal batch.** A private execution engine preserves the Toolset registry and legacy per-call API while centralizing ordered results, deduplication, callbacks, and batch summaries; cancellation is bounded, late work stays owned, and new batches fail closed until timed-out cleanup drains.
+
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.59.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 ## 0.58.0 (2026-07-11)
 

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code_0.58.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code_0.58.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.58.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.58.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code_0.59.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code_0.59.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.59.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.59.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code-0.58.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.58.0/pythinker-code-0.58.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.58.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.58.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code-0.59.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.59.0/pythinker-code-0.59.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.59.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.59.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.58.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.59.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -36,13 +36,13 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.58.0
+bash packages/linux-installer/build.sh 0.59.0
 ```
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.58.0_amd64.deb`
-- `pythinker-code-0.58.0.x86_64.rpm`
+- `pythinker-code_0.59.0_amd64.deb`
+- `pythinker-code-0.59.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.58.0"
+version = "0.59.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2527,7 +2527,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.58.0"
+version = "0.59.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Release prep for **0.59.0**.

- Bump version 0.58.0 -> 0.59.0 across `pyproject.toml`, `uv.lock`, README, docs, and installer references.
- Consume Unreleased into a new `0.59.0 (2026-07-17)` CHANGELOG section (deterministic reviewer Git scopes, safe streamed tool-call correlation, explicit provider compatibility and Z.AI routing, supervised terminal-batch tool execution) and sync `docs/en/release-notes/changelog.md`.
- Add 0.59.0 entry to `docs/en/release-notes/breaking-changes.md` (no breaking changes).

Local gates passed: version-tag check, README/CHANGELOG greps, dependency-version check (all 5 pyprojects), `tests/test_installation_docs.py` + `tests/test_homebrew_formula.py` (17 passed), no stale 0.58.0 references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable reviewer scope handling and safer streamed tool-call processing.
  * Improved compatibility routing and credential support for Z.AI providers.
  * Added supervised terminal-batch execution with controlled cancellation and failure handling.

* **Documentation**
  * Updated release notes and installation guidance for version 0.59.0.
  * Updated Windows and Linux package names, download links, checksum verification, and installation commands.
  * Updated local Linux installer build instructions and artifact names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->