### PR TITLE
fix(auth+shell): PR #215 review remediation and running-prompt ghost fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ wheels/
 .env.local
 AGENTS.local
 /tests_local
+/tasks/
 uv.toml
 .idea/*
 .superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - Discover each provider's models from a cached, typed, provider-neutral models.dev catalog with curated fallbacks, so xAI, GitHub Copilot, and Snowflake pick up new models automatically; the catalog is now portable across platforms (no longer Unix-only) and distinguishes fresh, cached, stale, disabled, and unavailable results.
 - Persist provider login and logout atomically so a failed save never leaves orphaned credentials or a half-applied configuration; a re-login whose save fails now restores the previous credential instead of deleting it, and provider persistence failures are logged.
 - Fix queued follow-up input showing a bordered ghost; pressing Enter during an active turn now shows one intentional queued row.
+- Harden provider OAuth credential handling: scope token refresh to the active/selected provider, serialize persistence under a lock with atomic config replacement, roll back replaced credentials when a save fails, fail closed on credential migration, and validate OAuth token and implicit-state responses.
+- Fix an intermittent doubled/"ghost" copy of the running-prompt block (agent tree, spinner, and tip) on long streaming turns: after a scrollback handoff the suppressed live body now waits for the terminal's re-requested absolute cursor position to settle before it re-expands, so it repaints against a correct cursor model instead of the mis-anchored frame left behind by `run_in_terminal`.
 
 ## 0.60.0 (2026-07-18)
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -24,6 +24,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 - Discover each provider's models from a cached, typed, provider-neutral models.dev catalog with curated fallbacks, so xAI, GitHub Copilot, and Snowflake pick up new models automatically; the catalog is now portable across platforms (no longer Unix-only) and distinguishes fresh, cached, stale, disabled, and unavailable results.
 - Persist provider login and logout atomically so a failed save never leaves orphaned credentials or a half-applied configuration; a re-login whose save fails now restores the previous credential instead of deleting it, and provider persistence failures are logged.
 - Fix queued follow-up input showing a bordered ghost; pressing Enter during an active turn now shows one intentional queued row.
+- Harden provider OAuth credential handling: scope token refresh to the active/selected provider, serialize persistence under a lock with atomic config replacement, roll back replaced credentials when a save fails, fail closed on credential migration, and validate OAuth token and implicit-state responses.
+- Fix an intermittent doubled/"ghost" copy of the running-prompt block (agent tree, spinner, and tip) on long streaming turns: after a scrollback handoff the suppressed live body now waits for the terminal's re-requested absolute cursor position to settle before it re-expands, so it repaints against a correct cursor model instead of the mis-anchored frame left behind by `run_in_terminal`.
 
 ## 0.60.0 (2026-07-18)
 

--- a/docs/superpowers/specs/2026-07-18-pr-215-auth-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-18-pr-215-auth-review-fixes-design.md
@@ -18,17 +18,21 @@ Resolve every validated review defect on PR #215 without broad auth or configura
 5. Log curated-model fallback both when catalog status is non-authoritative and when an authoritative catalog yields no usable provider models.
 6. Preserve the existing OpenCode Go unavailable-catalog regression test and resolve its stale review thread with evidence.
 
-Out of scope: provider protocol redesigns, replacing DigitalOcean's provider-required implicit grant, Snowflake Cortex chat transforms, global config merge semantics unrelated to these auth transactions, and new dependencies.
+Out of scope: provider protocol redesigns, replacing DigitalOcean's provider-required implicit grant, Snowflake Cortex chat transforms, global config merge semantics outside these auth transactions, and new dependencies.
 
 ## Design
 
 ### Credential filenames
 
-Keep the legacy filename for ordinary one-segment OAuth keys so existing credentials remain readable. Encode the complete relative key for multi-segment keys into a deterministic, filesystem-safe filename, and apply the same mapping to lock files. This makes the mapping injective without changing released flat-key paths.
+Keep the legacy filename for canonical lowercase `oauth/<safe-segment>` keys so existing credentials remain readable. Encode every other complete key as lowercase hex beneath a dedicated `credentials/v2/` directory, and apply the same mapping to lock files. This keeps identities injective on case-insensitive filesystems without changing released flat-key paths.
+
+Keyring migration reads and validates the credential, writes the file copy, confirms keyring deletion, and only then changes the config reference to file storage. A missing credential leaves the keyring reference unchanged. Backend read/delete errors are safe typed failures; failed cleanup rolls back the file copy and reports a combined failure if rollback also fails.
 
 ### Persistence transaction
 
-Expose async persistence helpers to provider login/logout callers. Each helper offloads one complete synchronous transaction to a worker thread. The transaction acquires a bounded, fail-closed inter-process lock derived from the default config path before it snapshots credentials/config, mutates state, writes, or rolls back.
+Expose async persistence helpers to provider login/logout callers. Each helper offloads one complete synchronous transaction to a worker thread. The transaction acquires a bounded, fail-closed inter-process lock derived from the default config path before it snapshots credentials/config, mutates state, writes, or rolls back. Login, logout, replacement, migration, and refresh also share sorted per-credential locks beneath the config lock.
+
+Cancellation uses an atomic phase handshake: cancellation before mutation leaves no effects; cancellation after mutation waits for the owned worker transaction to settle before re-raising. Lock contention is a typed failure and never falls back to an unlocked write.
 
 Config writes use a temporary file in the target directory, flush and fsync it, apply private permissions, and atomically replace the destination. A failed write therefore leaves the previous config file intact.
 
@@ -38,6 +42,20 @@ Logout writes the config removal first, then deletes credentials. If deletion fa
 
 The config-scoped lock covers snapshot through rollback, so a failed concurrent login cannot restore a token observed before another successful transaction.
 
+The transaction reloads the authoritative default config after acquiring the lock, applies the requested provider mutation to that fresh object, persists it, and only then synchronizes the caller's in-memory config. This prevents two serialized sessions with stale `Config` objects from silently replacing each other's provider changes.
+
+An account-scoped provider replacement supplies its provider key to the login transaction, which resolves the previous OAuth reference from the authoritative config while holding the lock. Equal credential keys skip cleanup even if storage metadata differs. After the new token and config commit, the transaction removes a genuinely replaced credential; rollback ordering preserves at least one loadable config/credential pair before surfacing an explicit persistence error.
+
+Background model discovery works on a deep copy, records the provider identity used for each request, and applies collected results through the same authoritative config transaction. Results are skipped if the target provider was logged out or replaced while discovery was in flight; unrelated concurrent provider changes are preserved. Snowflake logout likewise resolves the current account credential from the authoritative locked provider entry rather than trusting a stale caller.
+
+### Active-provider refresh
+
+Runtime refreshes derive the OAuth reference from the active model's provider and never iterate unrelated configured providers. Provider-catalog refresh and title generation pass their already-selected provider reference explicitly. Untargeted compatibility callers retain the existing aggregate behavior only when they provide neither a runtime nor a reference.
+
+### Token response validation
+
+`OAuthToken.from_response()` is the shared trust boundary for provider token responses. It requires a non-empty string access token, accepts an omitted lifetime as unknown, rejects supplied boolean, negative, non-finite, or otherwise malformed lifetimes, and rejects non-string refresh tokens. Provider iterators translate those typed errors into safe error events before any persistence or success event.
+
 ### OAuth callback validation
 
 For implicit callbacks, parse `state` and compare it with the expected value before interpreting `error`. RFC 6749 requires the original state on both successful and error responses. A wrong-state error is rejected as `OAuthStateMismatch`, not accepted as a user denial.
@@ -45,6 +63,12 @@ For implicit callbacks, parse `state` and compare it with the expected value bef
 ### Provider messaging and fallback visibility
 
 DigitalOcean continues to persist a valid OAuth token when router discovery is empty or unavailable, matching the approved PR scope. Its terminal success text distinguishes “router configured” from “credentials saved with no routers configured.”
+
+Router discovery treats only an actually empty router list as authoritative empty data. An all-invalid non-empty list is malformed; a mixed list is partial and keeps valid router names while emitting an explicit degraded-status event.
+
+The implicit loopback callback rejects malformed or negative body lengths and returns `413 Payload Too Large` before reading any body above 64 KiB. Empty and whitespace-only access tokens fail before catalog access, persistence, or success output.
+
+Snowflake supplies its ten-minute default lifetime only when `expires_in` is absent or `None`; explicit falsy values retain the shared token validator's normal semantics.
 
 Copilot, xAI, and Snowflake log when they use curated models because the catalog is non-authoritative or because authoritative conversion is empty. Logs include status/source only, never credentials.
 
@@ -61,6 +85,19 @@ Use red-green TDD for each behavior:
 - DigitalOcean degraded success does not name an unrelated model;
 - empty authoritative catalogs emit fallback logs;
 - unavailable OpenCode Go catalog coverage remains green.
+- inactive configured OAuth providers cannot abort refresh of the active runtime provider;
+- independently loaded configs preserve both serialized provider updates;
+- Snowflake account replacement removes the prior account credential transactionally;
+- malformed shared token responses fail before persistence or success;
+- malformed and partial DigitalOcean router payloads remain distinguishable;
+- oversized implicit callback bodies fail before allocation or blocking reads.
+- lock contention and cancellation cannot produce late or unlocked persistence;
+- credential and lock paths remain injective across prefixed, nested, case-variant, and unsafe keys;
+- keyring read/delete/migration/rollback failures leave config and credentials truthful;
+- stale model discovery cannot resurrect a logged-out or replaced provider;
+- Snowflake logout deletes the authoritative account credential even from a stale caller;
+- blank implicit callback tokens fail before DigitalOcean persistence;
+- Snowflake expiry defaulting preserves explicit falsy values for shared validation.
 
 After focused tests, run `make check-pythinker-code`, `make test-pythinker-code`, and `git diff --check`.
 

--- a/src/pythinker_code/auth/digitalocean.py
+++ b/src/pythinker_code/auth/digitalocean.py
@@ -33,6 +33,7 @@ class RouterDiscovery(str, Enum):
     """Outcome of a DigitalOcean inference-router discovery call."""
 
     OK = "ok"  # routers were discovered
+    PARTIAL = "partial"  # valid routers were discovered alongside malformed entries
     EMPTY = "empty"  # the account has no routers (valid, but empty)
     UNAUTHORIZED = "unauthorized"  # the token could not list routers
     UNAVAILABLE = "unavailable"  # timeout / outage / non-2xx response
@@ -92,15 +93,22 @@ def _parse_router_names(payload: object) -> RouterCatalog:
     raw = cast(dict[str, Any], payload).get("model_routers")
     if not isinstance(raw, list):
         return RouterCatalog(RouterDiscovery.MALFORMED, ())
+    if not raw:
+        return RouterCatalog(RouterDiscovery.EMPTY, ())
 
     names: list[str] = []
+    has_malformed_entry = False
     for item in cast(list[Any], raw):
         if isinstance(item, dict):
             name = cast(dict[str, Any], item).get("name")
-            if isinstance(name, str) and name:
+            if isinstance(name, str) and name.strip():
                 names.append(name)
+                continue
+        has_malformed_entry = True
     if not names:
-        return RouterCatalog(RouterDiscovery.EMPTY, ())
+        return RouterCatalog(RouterDiscovery.MALFORMED, ())
+    if has_malformed_entry:
+        return RouterCatalog(RouterDiscovery.PARTIAL, tuple(names))
     return RouterCatalog(RouterDiscovery.OK, tuple(names))
 
 
@@ -141,8 +149,18 @@ async def _fetch_router_catalog(access_token: str) -> RouterCatalog:
 def _router_status_message(status: RouterDiscovery) -> str | None:
     if status is RouterDiscovery.OK:
         return None
+    if status is RouterDiscovery.PARTIAL:
+        return (
+            "DigitalOcean returned some malformed inference-router entries; sign-in saved "
+            "with valid routers configured and malformed entries ignored."
+        )
     if status is RouterDiscovery.EMPTY:
         return "DigitalOcean returned no inference routers; sign-in saved with no models."
+    if status is RouterDiscovery.MALFORMED:
+        return (
+            "DigitalOcean returned entirely malformed inference-router data; sign-in saved "
+            "with no models configured."
+        )
     if status is RouterDiscovery.UNAUTHORIZED:
         return (
             "DigitalOcean did not authorize inference-router discovery; sign-in saved. "

--- a/src/pythinker_code/auth/oauth.py
+++ b/src/pythinker_code/auth/oauth.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
+import math
 import os
 import platform
 import random
+import re
 import socket
 import sys
 import tempfile
+import threading
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Callable
-from contextlib import asynccontextmanager, suppress
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Generator
+from contextlib import asynccontextmanager, contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -37,13 +39,14 @@ from pythinker_code.config import (
     PythinkerAIFetchConfig,
     PythinkerAISearchConfig,
     get_config_file,
+    load_config,
     save_config,
 )
 from pythinker_code.constant import VERSION
 from pythinker_code.share import get_share_dir
 from pythinker_code.thinking import apply_login_thinking_defaults
 from pythinker_code.utils.aiohttp import new_client_session
-from pythinker_code.utils.io import file_lock
+from pythinker_code.utils.io import FileLockTimeoutError, file_lock
 from pythinker_code.utils.logging import logger
 
 if TYPE_CHECKING:
@@ -59,7 +62,17 @@ MIN_REFRESH_THRESHOLD_SECONDS = 300
 REFRESH_THRESHOLD_RATIO = 0.5
 UNAUTHORIZED_REFRESH_RETRY_COOLDOWN_SECONDS = 300
 _CROSS_PROCESS_LOCK_RETRIES = 5
+_PERSISTENCE_LOCK_TIMEOUT_SECONDS = 5.0
 _RETRYABLE_REFRESH_STATUSES = {429, 500, 502, 503, 504}
+_SAFE_CREDENTIAL_KEY_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+_WINDOWS_RESERVED_CREDENTIAL_BASENAMES = {
+    "AUX",
+    "CON",
+    "NUL",
+    "PRN",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
 
 
 def _refresh_threshold(expires_in: float) -> float:
@@ -79,6 +92,14 @@ class OAuthUnauthorized(OAuthError):
 
 class OAuthPersistenceError(OAuthError):
     """OAuth credentials and configuration could not be persisted consistently."""
+
+
+class _KeyringCredentialPresentError(OAuthPersistenceError):
+    """Keyring deletion failed and the credential is confirmed to remain."""
+
+
+class _KeyringDeleteOutcomeUnknownError(OAuthPersistenceError):
+    """Keyring deletion failed and the credential state could not be verified."""
 
 
 class _RetryableRefreshError(OAuthError):
@@ -121,10 +142,34 @@ class OAuthToken:
 
     @classmethod
     def from_response(cls, payload: dict[str, Any]) -> OAuthToken:
-        expires_in = float(payload.get("expires_in") or 0)
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            raise OAuthError("OAuth token response contained an invalid access token.")
+
+        refresh_token = payload.get("refresh_token", "")
+        if not isinstance(refresh_token, str):
+            raise OAuthError("OAuth token response contained an invalid refresh token.")
+
+        expires_in_value = payload.get("expires_in")
+        if expires_in_value is None or expires_in_value == "":
+            expires_in = 0.0
+        else:
+            if isinstance(expires_in_value, bool) or not isinstance(
+                expires_in_value, (int, float, str)
+            ):
+                raise OAuthError("OAuth token response contained an invalid expiration lifetime.")
+            try:
+                expires_in = float(expires_in_value)
+            except (OverflowError, ValueError):
+                raise OAuthError(
+                    "OAuth token response contained an invalid expiration lifetime."
+                ) from None
+            if not math.isfinite(expires_in) or expires_in < 0:
+                raise OAuthError("OAuth token response contained an invalid expiration lifetime.")
+
         return cls(
-            access_token=str(payload["access_token"]),
-            refresh_token=str(payload.get("refresh_token") or ""),
+            access_token=access_token,
+            refresh_token=refresh_token,
             expires_at=time.time() + expires_in,
             scope=str(payload.get("scope") or ""),
             token_type=str(payload.get("token_type") or ""),
@@ -304,22 +349,35 @@ def _credentials_dir() -> Path:
     return path
 
 
-def _credential_file_stem(key: str) -> str:
+def _is_safe_legacy_credential_key(key: str) -> bool:
+    if not _SAFE_CREDENTIAL_KEY_SEGMENT.fullmatch(key) or key.endswith("."):
+        return False
+    return key.split(".", maxsplit=1)[0].upper() not in _WINDOWS_RESERVED_CREDENTIAL_BASENAMES
+
+
+def _credential_relative_path(key: str) -> Path:
     relative_key = key.removeprefix("oauth/")
-    if "/" not in relative_key:
-        return relative_key or key
-    encoded = base64.urlsafe_b64encode(relative_key.encode(encoding="utf-8")).decode(
-        encoding="utf-8"
-    )
-    return f"v2-{encoded.rstrip('=')}"
+    if (
+        key.startswith("oauth/")
+        and relative_key == relative_key.lower()
+        and _is_safe_legacy_credential_key(relative_key)
+    ):
+        return Path(relative_key)
+    encoded = key.encode(encoding="utf-8").hex()
+    return Path("v2") / (encoded.rstrip("=") or "~")
+
+
+def _credential_path(key: str, suffix: str) -> Path:
+    relative_path = _credential_relative_path(key)
+    return _credentials_dir() / relative_path.parent / f"{relative_path.name}{suffix}"
 
 
 def _credentials_path(key: str) -> Path:
-    return _credentials_dir() / f"{_credential_file_stem(key)}.json"
+    return _credential_path(key, ".json")
 
 
 def _credentials_lock_path(key: str) -> Path:
-    return _credentials_dir() / f"{_credential_file_stem(key)}.lock"
+    return _credential_path(key, ".lock")
 
 
 class _CrossProcessLock:
@@ -338,6 +396,7 @@ class _CrossProcessLock:
         Returns ``True`` if locked, ``False`` on contention.
         Raises ``OSError`` if the lock file cannot be opened (permanent failure).
         """
+        self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         self._fd = os.open(str(self._path), os.O_CREAT | os.O_RDWR, 0o600)
         try:
             if sys.platform == "win32":
@@ -379,10 +438,24 @@ class _CrossProcessLock:
                     return True
             except OSError:
                 # Cannot open/create the lock file (permissions, read-only FS, etc.).
-                # Permanent failure — skip backoff and fall back to unlocked refresh.
+                # Permanent failure — skip backoff and fail closed.
                 return False
             await asyncio.sleep(1 + random.random())
             # After waiting, re-check if the token was refreshed by the holder.
+        try:
+            return self._acquire()
+        except OSError:
+            return False
+
+    def acquire_with_retry_sync(self) -> bool:
+        """Synchronous counterpart for persistence workers already off the event loop."""
+        for _attempt in range(_CROSS_PROCESS_LOCK_RETRIES):
+            try:
+                if self._acquire():
+                    return True
+            except OSError:
+                return False
+            time.sleep(1 + random.random())
         try:
             return self._acquire()
         except OSError:
@@ -395,32 +468,71 @@ class _CrossProcessLock:
         self.release()
 
 
-def _load_from_keyring(key: str) -> OAuthToken | None:
+def _read_keyring_value(key: str) -> str | None:
     try:
-        raw = keyring.get_password(KEYRING_SERVICE, key)
+        return keyring.get_password(KEYRING_SERVICE, key)
     except Exception as exc:
         from pythinker_code.telemetry.errors import report_handled_error
 
         report_handled_error(exc, site="auth.keyring.read")
-        logger.warning("Failed to read token from keyring: {error}", error=exc)
-        return None
+        logger.warning(
+            "Failed to read OAuth credentials from the system keyring ({error_type}).",
+            error_type=type(exc).__name__,
+        )
+        raise OAuthPersistenceError(
+            "Could not read OAuth credentials from the system keyring."
+        ) from exc
+
+
+def _load_from_keyring(key: str) -> OAuthToken | None:
+    raw = _read_keyring_value(key)
     if not raw:
         return None
     try:
         payload = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
+    except json.JSONDecodeError as exc:
+        raise OAuthPersistenceError("OAuth credentials in the system keyring are invalid.") from exc
     if not isinstance(payload, dict):
-        return None
+        raise OAuthPersistenceError("OAuth credentials in the system keyring are invalid.")
     payload = cast(dict[str, Any], payload)
-    return OAuthToken.from_dict(payload)
+    try:
+        return OAuthToken.from_dict(payload)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise OAuthPersistenceError("OAuth credentials in the system keyring are invalid.") from exc
+
+
+def _report_keyring_delete_error(exc: Exception) -> None:
+    from pythinker_code.telemetry.errors import report_handled_error
+
+    report_handled_error(exc, site="auth.keyring.delete")
+    logger.warning(
+        "Failed to remove OAuth credentials from the system keyring ({error_type}).",
+        error_type=type(exc).__name__,
+    )
 
 
 def _delete_from_keyring(key: str) -> None:
+    if _read_keyring_value(key) is None:
+        return
     try:
         keyring.delete_password(KEYRING_SERVICE, key)
-    except Exception:
-        return
+    except Exception as delete_error:
+        _report_keyring_delete_error(delete_error)
+        try:
+            remaining = _read_keyring_value(key)
+        except OAuthPersistenceError as verification_error:
+            failures = ExceptionGroup(
+                "Keyring deletion and verification both failed.",
+                [delete_error, verification_error],
+            )
+            raise _KeyringDeleteOutcomeUnknownError(
+                "Could not verify whether OAuth credentials were removed from the system keyring."
+            ) from failures
+        if remaining is None:
+            return
+        raise _KeyringCredentialPresentError(
+            "Could not remove OAuth credentials from the system keyring."
+        ) from delete_error
 
 
 def _load_from_file(key: str) -> OAuthToken | None:
@@ -437,11 +549,11 @@ def _load_from_file(key: str) -> OAuthToken | None:
     return OAuthToken.from_dict(payload)
 
 
-def _save_to_file(key: str, token: OAuthToken) -> None:
+def _write_credential_file(key: str, data: bytes) -> None:
     path = _credentials_path(key)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
-        data = json.dumps(token.to_dict(), ensure_ascii=False).encode("utf-8")
         written = os.write(fd, data)
         if written != len(data):
             raise OSError(f"Short write: {written}/{len(data)} bytes")
@@ -464,29 +576,73 @@ def _save_to_file(key: str, token: OAuthToken) -> None:
         raise
 
 
+def _save_to_file(key: str, token: OAuthToken) -> None:
+    data = json.dumps(token.to_dict(), ensure_ascii=False).encode("utf-8")
+    _write_credential_file(key, data)
+
+
 def _delete_from_file(key: str) -> None:
     path = _credentials_path(key)
     if path.exists():
         path.unlink()
 
 
-def load_tokens(ref: OAuthRef) -> OAuthToken | None:
-    file_token = _load_from_file(ref.key)
-    if file_token is not None:
-        return file_token
-    if ref.storage != "keyring":
+def _credential_file_snapshot(key: str) -> bytes | None:
+    try:
+        return _credentials_path(key).read_bytes()
+    except FileNotFoundError:
         return None
+    except OSError as exc:
+        raise OAuthPersistenceError("Could not snapshot the OAuth credential file.") from exc
+
+
+def _restore_credential_file_snapshot(key: str, snapshot: bytes | None) -> None:
+    if snapshot is None:
+        _delete_from_file(key)
+    else:
+        _write_credential_file(key, snapshot)
+
+
+def _migrate_keyring_token(ref: OAuthRef) -> OAuthToken | None:
+    file_snapshot = _credential_file_snapshot(ref.key)
     token = _load_from_keyring(ref.key)
     if token is None:
-        return None
+        return _load_from_file(ref.key)
+
     try:
         _save_to_file(ref.key, token)
     except OSError as exc:
-        logger.warning("Failed to migrate token from keyring to file: {error}", error=exc)
-    else:
-        with suppress(Exception):
-            _delete_from_keyring(ref.key)
+        raise OAuthPersistenceError(
+            "Could not copy OAuth credentials out of the system keyring."
+        ) from exc
+    try:
+        _delete_from_keyring(ref.key)
+    except _KeyringDeleteOutcomeUnknownError as cleanup_error:
+        raise OAuthPersistenceError(
+            "OAuth keyring migration cleanup could not be verified; the authoritative file copy "
+            "was retained."
+        ) from cleanup_error
+    except _KeyringCredentialPresentError as cleanup_error:
+        try:
+            _restore_credential_file_snapshot(ref.key, file_snapshot)
+        except OSError as rollback_error:
+            failures = ExceptionGroup(
+                "Keyring cleanup and credential file rollback both failed.",
+                [cleanup_error, rollback_error],
+            )
+            raise OAuthPersistenceError(
+                "OAuth keyring migration cleanup failed and file rollback also failed."
+            ) from failures
+        raise OAuthPersistenceError(
+            "OAuth keyring migration cleanup failed; the file copy was rolled back."
+        ) from cleanup_error
     return token
+
+
+def load_tokens(ref: OAuthRef) -> OAuthToken | None:
+    if ref.storage == "keyring":
+        return _migrate_keyring_token(ref)
+    return _load_from_file(ref.key)
 
 
 def save_tokens(ref: OAuthRef, token: OAuthToken) -> OAuthRef:
@@ -509,35 +665,205 @@ def restore_config_state(config: Config, snapshot: Config) -> None:
         setattr(config, field_name, getattr(snapshot, field_name))
 
 
+def _load_transaction_config(config: Config) -> Config:
+    config_file = get_config_file()
+    if config_file.exists():
+        return load_config(config_file)
+    return config.model_copy(deep=True)
+
+
+def _restore_token_snapshot(ref: OAuthRef, token: OAuthToken | None) -> None:
+    if token is not None:
+        save_tokens(ref, token)
+    else:
+        delete_tokens(ref)
+
+
+def _load_token_snapshot(ref: OAuthRef) -> OAuthToken | None:
+    if ref.storage == "keyring":
+        token = _load_from_keyring(ref.key)
+        if token is not None:
+            return token
+    return _load_from_file(ref.key)
+
+
+class _PersistenceMutationPhase:
+    """Atomic cancellation handshake between the event loop and persistence worker."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cancel_requested = False
+        self._mutation_started = False
+
+    def begin_mutation(self) -> bool:
+        with self._lock:
+            if self._cancel_requested:
+                return False
+            self._mutation_started = True
+            return True
+
+    def request_cancel(self) -> bool:
+        with self._lock:
+            self._cancel_requested = True
+            return self._mutation_started
+
+
+@contextmanager
+def _config_transaction_lock() -> Generator[None]:
+    try:
+        with file_lock(get_config_file(), timeout=_PERSISTENCE_LOCK_TIMEOUT_SECONDS):
+            yield
+    except FileLockTimeoutError as exc:
+        raise OAuthPersistenceError(
+            "OAuth persistence is busy; wait for the other operation and try again."
+        ) from exc
+
+
+@contextmanager
+def _credential_transaction_locks(keys: list[str]) -> Generator[None]:
+    locks: list[_CrossProcessLock] = []
+    try:
+        for key in sorted(set(keys)):
+            try:
+                lock = _CrossProcessLock(key)
+                acquired = lock.acquire_with_retry_sync()
+            except OSError as exc:
+                raise OAuthPersistenceError(
+                    "Could not acquire the OAuth credential lock; no changes were made."
+                ) from exc
+            if not acquired:
+                raise OAuthPersistenceError(
+                    "Could not acquire the OAuth credential lock; no changes were made."
+                )
+            locks.append(lock)
+        yield
+    finally:
+        for lock in reversed(locks):
+            lock.release()
+
+
+async def _run_persistence_operation(
+    operation: Callable[[_PersistenceMutationPhase], None],
+) -> None:
+    phase = _PersistenceMutationPhase()
+    worker = asyncio.create_task(asyncio.to_thread(operation, phase))
+    try:
+        await asyncio.shield(worker)
+    except asyncio.CancelledError as cancellation:
+        phase.request_cancel()
+        while not worker.done():
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        worker_error = None if worker.cancelled() else worker.exception()
+        if worker_error is not None:
+            logger.warning(
+                "OAuth persistence transaction failed while caller cancellation was pending."
+            )
+            failures = BaseExceptionGroup(
+                "OAuth persistence failed while cancellation was pending.",
+                [cancellation, worker_error],
+            )
+            raise OAuthPersistenceError(
+                "OAuth persistence failed while cancellation was pending."
+            ) from failures
+        raise cancellation
+
+
 def _persist_login_sync(
     config: Config,
     ref: OAuthRef,
     token: OAuthToken,
     apply_config: Callable[[Config], None],
+    phase: _PersistenceMutationPhase,
+    *,
+    replace_provider_key: str | None = None,
 ) -> None:
-    with file_lock(get_config_file()):
-        snapshot = config.model_copy(deep=True)
-        previous_token = load_tokens(ref)
-        save_tokens(ref, token)
-        try:
-            apply_config(config)
-            save_config(config)
-        except BaseException as persistence_error:
-            restore_config_state(config, snapshot)
+    with _config_transaction_lock():
+        committed = _load_transaction_config(config)
+        config_snapshot = committed.model_copy(deep=True)
+        replaced_ref: OAuthRef | None = None
+        if replace_provider_key is not None:
+            provider = committed.providers.get(replace_provider_key)
+            if (
+                provider is not None
+                and provider.oauth is not None
+                and provider.oauth.key != ref.key
+            ):
+                replaced_ref = provider.oauth
+
+        credential_keys = [ref.key]
+        if replaced_ref is not None:
+            credential_keys.append(replaced_ref.key)
+        with _credential_transaction_locks(credential_keys):
+            if not phase.begin_mutation():
+                return
+            previous_token = load_tokens(ref)
+            replaced_token = load_tokens(replaced_ref) if replaced_ref is not None else None
+            save_tokens(ref, token)
             try:
-                if previous_token is not None:
-                    save_tokens(ref, previous_token)
-                else:
-                    delete_tokens(ref)
-            except Exception as rollback_error:
-                logger.error(
-                    "Failed to roll back OAuth login persistence: {error}",
-                    error=rollback_error,
-                )
-                raise OAuthPersistenceError(
-                    "OAuth login persistence failed and credential rollback also failed."
-                ) from persistence_error
-            raise
+                apply_config(committed)
+                save_config(committed)
+            except BaseException as persistence_error:
+                try:
+                    _restore_token_snapshot(ref, previous_token)
+                except Exception as rollback_error:
+                    logger.error(
+                        "Failed to roll back OAuth login persistence: {error}",
+                        error=rollback_error,
+                    )
+                    raise OAuthPersistenceError(
+                        "OAuth login persistence failed and credential rollback also failed."
+                    ) from persistence_error
+                raise
+
+            if replaced_ref is not None:
+                try:
+                    delete_tokens(replaced_ref)
+                except Exception as cleanup_error:
+                    try:
+                        _restore_token_snapshot(replaced_ref, replaced_token)
+                    except Exception as rollback_error:
+                        logger.error(
+                            "Failed to restore replaced OAuth credential after cleanup failure: "
+                            "{error}",
+                            error=rollback_error,
+                        )
+                        raise OAuthPersistenceError(
+                            "OAuth login credential cleanup failed and replaced credential "
+                            "rollback also failed."
+                        ) from cleanup_error
+                    try:
+                        save_config(config_snapshot)
+                    except Exception as rollback_error:
+                        logger.error(
+                            "Failed to restore configuration after OAuth credential cleanup "
+                            "failure: {error}",
+                            error=rollback_error,
+                        )
+                        raise OAuthPersistenceError(
+                            "OAuth login credential cleanup failed and configuration rollback "
+                            "also failed."
+                        ) from cleanup_error
+                    try:
+                        _restore_token_snapshot(ref, previous_token)
+                    except Exception as rollback_error:
+                        logger.error(
+                            "Failed to restore new OAuth credential after cleanup rollback: "
+                            "{error}",
+                            error=rollback_error,
+                        )
+                        raise OAuthPersistenceError(
+                            "OAuth login credential cleanup failed and new credential rollback "
+                            "also failed."
+                        ) from cleanup_error
+                    raise OAuthPersistenceError(
+                        "OAuth login credential cleanup failed; login was rolled back."
+                    ) from cleanup_error
+            restore_config_state(config, committed)
 
 
 async def persist_login(
@@ -545,70 +871,134 @@ async def persist_login(
     ref: OAuthRef,
     token: OAuthToken,
     apply_config: Callable[[Config], None],
+    *,
+    replace_provider_key: str | None = None,
 ) -> None:
     """Persist OAuth credentials and config together outside the event loop."""
-    await asyncio.to_thread(_persist_login_sync, config, ref, token, apply_config)
+
+    def operation(phase: _PersistenceMutationPhase) -> None:
+        _persist_login_sync(
+            config,
+            ref,
+            token,
+            apply_config,
+            phase,
+            replace_provider_key=replace_provider_key,
+        )
+
+    await _run_persistence_operation(operation)
 
 
 def _persist_logout_sync(
     config: Config,
-    ref: OAuthRef,
+    ref: OAuthRef | None,
     remove_config: Callable[[Config], None],
+    phase: _PersistenceMutationPhase,
+    *,
+    provider_key: str | None = None,
 ) -> None:
-    with file_lock(get_config_file()):
-        snapshot = config.model_copy(deep=True)
-        remove_config(config)
-        try:
-            save_config(config)
-        except BaseException:
-            restore_config_state(config, snapshot)
-            raise
-        try:
-            delete_tokens(ref)
-        except Exception as delete_error:
-            restore_config_state(config, snapshot)
+    with _config_transaction_lock():
+        committed = _load_transaction_config(config)
+        snapshot = committed.model_copy(deep=True)
+        credential_ref = ref
+        if provider_key is not None:
+            provider = committed.providers.get(provider_key)
+            credential_ref = provider.oauth if provider is not None else None
+        credential_keys = [credential_ref.key] if credential_ref is not None else []
+        with _credential_transaction_locks(credential_keys):
+            previous_token = (
+                _load_token_snapshot(credential_ref) if credential_ref is not None else None
+            )
+            if not phase.begin_mutation():
+                return
+            remove_config(committed)
+            save_config(committed)
             try:
-                save_config(config)
-            except Exception as rollback_error:
-                logger.error(
-                    "Failed to restore configuration after OAuth credential deletion failed: "
-                    "{error}",
-                    error=rollback_error,
-                )
+                if credential_ref is not None:
+                    delete_tokens(credential_ref)
+            except Exception as delete_error:
+                try:
+                    if credential_ref is not None and previous_token is not None:
+                        _restore_token_snapshot(credential_ref, previous_token)
+                except Exception as credential_rollback_error:
+                    restore_config_state(config, committed)
+                    logger.error(
+                        "Failed to restore OAuth credential after logout deletion failed "
+                        "({error_type}).",
+                        error_type=type(credential_rollback_error).__name__,
+                    )
+                    failures = ExceptionGroup(
+                        "OAuth credential deletion and restoration both failed.",
+                        [delete_error, credential_rollback_error],
+                    )
+                    raise OAuthPersistenceError(
+                        "OAuth logout partially completed: configuration was removed, but "
+                        "credential restoration failed."
+                    ) from failures
+                try:
+                    save_config(snapshot)
+                except Exception as rollback_error:
+                    logger.error(
+                        "Failed to restore configuration after OAuth credential deletion failed: "
+                        "{error_type}",
+                        error_type=type(rollback_error).__name__,
+                    )
+                    raise OAuthPersistenceError(
+                        "OAuth logout failed and configuration rollback also failed."
+                    ) from delete_error
                 raise OAuthPersistenceError(
-                    "OAuth logout failed and configuration rollback also failed."
+                    "OAuth credential deletion failed; logout was rolled back."
                 ) from delete_error
-            raise OAuthPersistenceError(
-                "OAuth credential deletion failed; logout was rolled back."
-            ) from delete_error
+            restore_config_state(config, committed)
 
 
 async def persist_logout(
     config: Config,
-    ref: OAuthRef,
+    ref: OAuthRef | None,
     remove_config: Callable[[Config], None],
+    *,
+    provider_key: str | None = None,
 ) -> None:
     """Persist OAuth logout outside the event loop, config removal first."""
-    await asyncio.to_thread(_persist_logout_sync, config, ref, remove_config)
+
+    def operation(phase: _PersistenceMutationPhase) -> None:
+        _persist_logout_sync(
+            config,
+            ref,
+            remove_config,
+            phase,
+            provider_key=provider_key,
+        )
+
+    await _run_persistence_operation(operation)
 
 
 def _persist_config_change_sync(
     config: Config,
     apply_config: Callable[[Config], None],
+    phase: _PersistenceMutationPhase,
+    *,
+    should_apply: Callable[[Config], bool] | None = None,
 ) -> None:
-    with file_lock(get_config_file()):
-        snapshot = config.model_copy(deep=True)
-        try:
-            apply_config(config)
-            save_config(config)
-        except BaseException:
-            restore_config_state(config, snapshot)
-            raise
+    with _config_transaction_lock():
+        committed = _load_transaction_config(config)
+        if should_apply is not None and not should_apply(committed):
+            restore_config_state(config, committed)
+            return
+        if not phase.begin_mutation():
+            return
+        apply_config(committed)
+        save_config(committed)
+        restore_config_state(config, committed)
 
 
 async def persist_config_change(config: Config, apply_config: Callable[[Config], None]) -> None:
     """Persist a config-only change atomically outside the event loop."""
-    await asyncio.to_thread(_persist_config_change_sync, config, apply_config)
+
+    def operation(phase: _PersistenceMutationPhase) -> None:
+        _persist_config_change_sync(config, apply_config, phase)
+
+    await _run_persistence_operation(operation)
 
 
 async def request_device_authorization() -> DeviceAuthorization:
@@ -946,32 +1336,66 @@ class OAuthManager:
         return refs
 
     def _migrate_oauth_storage(self) -> None:
-        migrated_keys: set[str] = set()
-        changed = False
+        def has_keyring_refs(config: Config) -> bool:
+            if any(
+                provider.oauth and provider.oauth.storage == "keyring"
+                for provider in config.providers.values()
+            ):
+                return True
+            return any(
+                service and service.oauth and service.oauth.storage == "keyring"
+                for service in (
+                    config.services.pythinker_ai_search,
+                    config.services.pythinker_ai_fetch,
+                )
+            )
 
-        def _migrate_ref(ref: OAuthRef) -> OAuthRef:
-            nonlocal changed
-            if ref.storage != "keyring":
-                return ref
-            if ref.key not in migrated_keys:
-                load_tokens(ref)
-                migrated_keys.add(ref.key)
-            changed = True
-            return OAuthRef(storage="file", key=ref.key)
+        def migrate_config(config: Config) -> None:
+            migration_results: dict[str, bool] = {}
 
-        for provider in self._config.providers.values():
-            if provider.oauth:
-                provider.oauth = _migrate_ref(provider.oauth)
+            def migrate_ref(ref: OAuthRef) -> OAuthRef:
+                if ref.storage != "keyring":
+                    return ref
+                if ref.key not in migration_results:
+                    migration_results[ref.key] = load_tokens(ref) is not None
+                if not migration_results[ref.key]:
+                    return ref
+                return OAuthRef(storage="file", key=ref.key)
 
-        for service in (
-            self._config.services.pythinker_ai_search,
-            self._config.services.pythinker_ai_fetch,
-        ):
-            if service and service.oauth:
-                service.oauth = _migrate_ref(service.oauth)
+            refs = [
+                provider.oauth
+                for provider in config.providers.values()
+                if provider.oauth and provider.oauth.storage == "keyring"
+            ]
+            refs.extend(
+                service.oauth
+                for service in (
+                    config.services.pythinker_ai_search,
+                    config.services.pythinker_ai_fetch,
+                )
+                if service and service.oauth and service.oauth.storage == "keyring"
+            )
+            with _credential_transaction_locks([ref.key for ref in refs]):
+                for provider in config.providers.values():
+                    if provider.oauth:
+                        provider.oauth = migrate_ref(provider.oauth)
 
-        if changed and self._config.is_from_default_location:
-            save_config(self._config)
+                for service in (
+                    config.services.pythinker_ai_search,
+                    config.services.pythinker_ai_fetch,
+                ):
+                    if service and service.oauth:
+                        service.oauth = migrate_ref(service.oauth)
+
+        if self._config.is_from_default_location:
+            _persist_config_change_sync(
+                self._config,
+                migrate_config,
+                _PersistenceMutationPhase(),
+                should_apply=has_keyring_refs,
+            )
+        elif has_keyring_refs(self._config):
+            migrate_config(self._config)
 
     def _load_initial_tokens(self) -> None:
         for ref in self._iter_oauth_refs():
@@ -1065,7 +1489,13 @@ class OAuthManager:
                 return service.oauth
         return None
 
-    async def ensure_fresh(self, runtime: Runtime | None = None, *, force: bool = False) -> None:
+    async def ensure_fresh(
+        self,
+        runtime: Runtime | None = None,
+        *,
+        force: bool = False,
+        oauth_ref: OAuthRef | None = None,
+    ) -> None:
         """Load persisted tokens, cache them, and refresh if close to expiry.
 
         Args:
@@ -1074,8 +1504,16 @@ class OAuthManager:
                 generation) that only need the internal cache to be current.
             force: When True, skip the expiry-threshold check and always
                 attempt a refresh.  Used after receiving a 401 from the server.
+            oauth_ref: When provided, refresh only this OAuth credential.
         """
-        for ref in self._iter_oauth_refs():
+        refs = [oauth_ref] if oauth_ref is not None else self._iter_oauth_refs()
+        if oauth_ref is None and runtime is not None:
+            llm = runtime.llm
+            if llm is not None and llm.model_config is not None:
+                provider = runtime.config.providers.get(llm.model_config.provider)
+                refs = [provider.oauth] if provider is not None and provider.oauth else []
+
+        for ref in refs:
             token = load_tokens(ref)
             if token is None:
                 continue
@@ -1185,27 +1623,31 @@ class OAuthManager:
             # pythinker-code instances (terminal, VS Code, web).
             xlock = _CrossProcessLock(ref.key)
             acquired = await xlock.acquire_with_retry()
+            if not acquired:
+                logger.warning("Could not acquire cross-process lock for token refresh")
+                if force:
+                    raise OAuthPersistenceError(
+                        "Could not acquire the OAuth credential lock for token refresh."
+                    )
+                return
             try:
-                if acquired:
-                    # Triple-check after acquiring the lock — another process
-                    # may have refreshed while we waited.
-                    locked_token = load_tokens(ref)
-                    if locked_token and locked_token.refresh_token != refresh_token_value:
+                # Triple-check after acquiring the lock — another process
+                # may have refreshed while we waited.
+                locked_token = load_tokens(ref)
+                if locked_token and locked_token.refresh_token != refresh_token_value:
+                    self._clear_rejected_refresh_token(ref)
+                    self._cache_access_token(ref, locked_token)
+                    self._apply_access_token(runtime, ref, locked_token.access_token)
+                    return
+                if not force and locked_token:
+                    remaining = locked_token.expires_at - time.time()
+                    if locked_token.expires_at and remaining >= _refresh_threshold(
+                        locked_token.expires_in
+                    ):
                         self._clear_rejected_refresh_token(ref)
                         self._cache_access_token(ref, locked_token)
                         self._apply_access_token(runtime, ref, locked_token.access_token)
                         return
-                    if not force and locked_token:
-                        remaining = locked_token.expires_at - time.time()
-                        if locked_token.expires_at and remaining >= _refresh_threshold(
-                            locked_token.expires_in
-                        ):
-                            self._clear_rejected_refresh_token(ref)
-                            self._cache_access_token(ref, locked_token)
-                            self._apply_access_token(runtime, ref, locked_token.access_token)
-                            return
-                else:
-                    logger.warning("Could not acquire cross-process lock for token refresh")
 
                 try:
                     refreshed = await self._refresh_token_for_ref(ref, refresh_token_value)

--- a/src/pythinker_code/auth/oauth.py
+++ b/src/pythinker_code/auth/oauth.py
@@ -641,7 +641,13 @@ def _migrate_keyring_token(ref: OAuthRef) -> OAuthToken | None:
 
 def load_tokens(ref: OAuthRef) -> OAuthToken | None:
     if ref.storage == "keyring":
-        return _migrate_keyring_token(ref)
+        # Serialize the read-copy-delete keyring migration with credential writes
+        # so it cannot race persist_login/persist_logout and overwrite a newer
+        # file token with the older keyring value. The lock is reentrant per
+        # thread, so callers already inside a credential transaction (e.g.
+        # persist_login loading the previous token) do not deadlock.
+        with _credential_transaction_locks([ref.key]):
+            return _migrate_keyring_token(ref)
     return _load_from_file(ref.key)
 
 
@@ -719,11 +725,36 @@ def _config_transaction_lock() -> Generator[None]:
         ) from exc
 
 
+# Per-thread reentrancy guard for the credential lock. fcntl.flock (Unix) and
+# msvcrt.locking (Windows) deny a second acquisition of the same lock file within
+# one process, so a thread that already holds a key's lock must reference that
+# hold instead of re-acquiring it — otherwise nested acquisitions (e.g.
+# load_tokens() migrating a keyring credential while inside a persist transaction)
+# would self-deadlock.
+_HELD_CREDENTIAL_KEYS = threading.local()
+
+
+def _held_credential_key_counts() -> dict[str, int]:
+    counts: dict[str, int] | None = getattr(_HELD_CREDENTIAL_KEYS, "counts", None)
+    if counts is None:
+        counts = {}
+        _HELD_CREDENTIAL_KEYS.counts = counts
+    return counts
+
+
 @contextmanager
 def _credential_transaction_locks(keys: list[str]) -> Generator[None]:
+    held = _held_credential_key_counts()
+    bumped: list[str] = []
     locks: list[_CrossProcessLock] = []
     try:
         for key in sorted(set(keys)):
+            if held.get(key, 0) > 0:
+                # Reentrant: this thread already holds `key`'s cross-process lock;
+                # re-acquiring the same file lock would be denied by the OS.
+                held[key] += 1
+                bumped.append(key)
+                continue
             try:
                 lock = _CrossProcessLock(key)
                 acquired = lock.acquire_with_retry_sync()
@@ -736,8 +767,18 @@ def _credential_transaction_locks(keys: list[str]) -> Generator[None]:
                     "Could not acquire the OAuth credential lock; no changes were made."
                 )
             locks.append(lock)
+            held[key] = 1
+            bumped.append(key)
         yield
     finally:
+        # Decrement only what this invocation bumped (correct even on a partial
+        # acquisition), and release only the OS locks it actually acquired.
+        for key in bumped:
+            count = held.get(key, 0)
+            if count <= 1:
+                held.pop(key, None)
+            else:
+                held[key] = count - 1
         for lock in reversed(locks):
             lock.release()
 

--- a/src/pythinker_code/auth/oauth_flows.py
+++ b/src/pythinker_code/auth/oauth_flows.py
@@ -21,6 +21,7 @@ from pythinker_code.utils.aiohttp import new_client_session
 _DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
 _DEFAULT_DEVICE_INTERVAL = 5
 _SLOW_DOWN_INCREMENT = 5
+_MAX_IMPLICIT_CALLBACK_BODY_BYTES = 64 * 1024
 _IMPLICIT_BOOTSTRAP_HTML = """<!doctype html><html><body>
 <p>Finishing sign-in…</p>
 <script>
@@ -432,7 +433,38 @@ async def _handle_implicit_loopback_callback(
             header_text = header.decode(encoding="utf-8", errors="replace")
             name, separator, value = header_text.partition(":")
             if separator and name.strip().lower() == "content-length":
-                content_length = int(value.strip())
+                raw_content_length = value.strip()
+                if not raw_content_length.isascii() or not raw_content_length.isdecimal():
+                    await _write_http_response(
+                        writer,
+                        status="400 Bad Request",
+                        body=bytes('{"ok": false}', encoding="utf-8"),
+                        content_type="application/json",
+                    )
+                    if not result.done():
+                        result.set_exception(
+                            OAuthError("OAuth callback Content-Length was invalid.")
+                        )
+                    return
+
+                normalized_content_length = raw_content_length.lstrip("0") or "0"
+                maximum_content_length = str(_MAX_IMPLICIT_CALLBACK_BODY_BYTES)
+                if len(normalized_content_length) > len(maximum_content_length) or (
+                    len(normalized_content_length) == len(maximum_content_length)
+                    and normalized_content_length > maximum_content_length
+                ):
+                    await _write_http_response(
+                        writer,
+                        status="413 Payload Too Large",
+                        body=bytes('{"ok": false}', encoding="utf-8"),
+                        content_type="application/json",
+                    )
+                    if not result.done():
+                        result.set_exception(
+                            OAuthError("OAuth callback body exceeded the size limit.")
+                        )
+                    return
+                content_length = int(normalized_content_length)
 
         try:
             body = await reader.readexactly(content_length)
@@ -492,7 +524,7 @@ async def _handle_implicit_loopback_callback(
             return
 
         access_token = payload.get("access_token")
-        if not isinstance(access_token, str) or not access_token:
+        if not isinstance(access_token, str) or not access_token.strip():
             await _write_http_response(
                 writer,
                 status="400 Bad Request",

--- a/src/pythinker_code/auth/platforms.py
+++ b/src/pythinker_code/auth/platforms.py
@@ -17,7 +17,7 @@ from pythinker_code.auth import (
     SNOWFLAKE_CORTEX_PLATFORM_ID,
     XAI_PLATFORM_ID,
 )
-from pythinker_code.config import Config, LLMModel, load_config, save_config
+from pythinker_code.config import Config, LLMModel, LLMProvider
 from pythinker_code.llm import ModelCapability
 from pythinker_code.utils.aiohttp import new_client_session
 from pythinker_code.utils.logging import logger
@@ -256,6 +256,8 @@ async def refresh_managed_models(config: Config) -> bool:
     if not config.is_from_default_location:
         return False
 
+    working_config = config.model_copy(deep=True)
+
     from pythinker_code.auth.kimi import (
         KIMI_PROVIDER_KEY,
         KimiModel,
@@ -282,14 +284,35 @@ async def refresh_managed_models(config: Config) -> bool:
         refresh_z_ai_models,
     )
 
+    def provider_snapshot(*provider_keys: str) -> dict[str, LLMProvider | None]:
+        return {
+            provider_key: (
+                provider.model_copy(deep=True)
+                if (provider := working_config.providers.get(provider_key)) is not None
+                else None
+            )
+            for provider_key in provider_keys
+        }
+
+    def providers_match(
+        committed: Config,
+        expected: dict[str, LLMProvider | None],
+    ) -> bool:
+        return all(
+            committed.providers.get(provider_key) == provider
+            for provider_key, provider in expected.items()
+        )
+
     managed_providers = {
-        key: provider for key, provider in config.providers.items() if is_managed_provider_key(key)
+        key: provider
+        for key, provider in working_config.providers.items()
+        if is_managed_provider_key(key)
     }
     if not managed_providers:
         return False
 
     changed = False
-    updates: list[tuple[str, str, list[ModelInfo]]] = []
+    updates: list[tuple[str, str, list[ModelInfo], dict[str, LLMProvider | None]]] = []
     z_ai_provider_keys = {route.provider_key for route in ZAI_ROUTES}
     oauth_manager = None
     for provider_key, provider in managed_providers.items():
@@ -327,15 +350,19 @@ async def refresh_managed_models(config: Config) -> bool:
             logger.warning("Managed platform not found: {platform}", platform=platform_id)
             continue
 
+        if provider.oauth and oauth_manager is None:
+            from pythinker_code.auth.oauth import OAuthManager
+
+            oauth_manager = OAuthManager(working_config)
+        provider = working_config.providers.get(provider_key)
+        if provider is None:
+            continue
         fallback_api_key = provider.api_key.get_secret_value()
         api_key = fallback_api_key
         if provider.oauth:
-            if oauth_manager is None:
-                from pythinker_code.auth.oauth import OAuthManager
-
-                oauth_manager = OAuthManager(config)
+            assert oauth_manager is not None
             try:
-                await oauth_manager.ensure_fresh()
+                await oauth_manager.ensure_fresh(oauth_ref=provider.oauth)
             except Exception as exc:
                 from pythinker_code.telemetry.errors import report_handled_error
 
@@ -360,6 +387,7 @@ async def refresh_managed_models(config: Config) -> bool:
             and oauth_manager is not None
             else None
         )
+        query_snapshot = provider_snapshot(provider_key)
         try:
             models = await _list_models_for_managed_platform(
                 platform_id=platform_id,
@@ -373,8 +401,8 @@ async def refresh_managed_models(config: Config) -> bool:
                 if fallback_models is None:
                     continue
                 models = fallback_models
-                updates.append((provider_key, platform_id, models))
-                if _apply_models(config, provider_key, platform_id, models):
+                updates.append((provider_key, platform_id, models, query_snapshot))
+                if _apply_models(working_config, provider_key, platform_id, models):
                     changed = True
                 continue
             logger.warning(
@@ -383,7 +411,7 @@ async def refresh_managed_models(config: Config) -> bool:
             )
             refresh_exc: Exception | None = None
             try:
-                await oauth_manager.ensure_fresh(force=True)
+                await oauth_manager.ensure_fresh(force=True, oauth_ref=provider.oauth)
             except Exception as exc2:
                 from pythinker_code.telemetry.errors import report_handled_error
 
@@ -409,8 +437,8 @@ async def refresh_managed_models(config: Config) -> bool:
                 )
                 if fallback_models is not None:
                     models = fallback_models
-                    updates.append((provider_key, platform_id, models))
-                    if _apply_models(config, provider_key, platform_id, models):
+                    updates.append((provider_key, platform_id, models, query_snapshot))
+                    if _apply_models(working_config, provider_key, platform_id, models):
                         changed = True
                 continue
             retry_exc: Exception | None = None
@@ -432,8 +460,8 @@ async def refresh_managed_models(config: Config) -> bool:
                 )
                 if fallback_models is not None:
                     models = fallback_models
-                    updates.append((provider_key, platform_id, models))
-                    if _apply_models(config, provider_key, platform_id, models):
+                    updates.append((provider_key, platform_id, models, query_snapshot))
+                    if _apply_models(working_config, provider_key, platform_id, models):
                         changed = True
                 continue
         except Exception as exc:
@@ -445,30 +473,34 @@ async def refresh_managed_models(config: Config) -> bool:
                 continue
             models = fallback_models
 
-        updates.append((provider_key, platform_id, models))
-        if _apply_models(config, provider_key, platform_id, models):
+        updates.append((provider_key, platform_id, models, query_snapshot))
+        if _apply_models(working_config, provider_key, platform_id, models):
             changed = True
 
     opencode_go_models: tuple[OpenCodeGoModel, ...] | None = None
+    opencode_go_snapshot = provider_snapshot(*OPENCODE_GO_PROVIDER_KEYS)
     try:
-        opencode_go_models = await refresh_opencode_go_models(config)
+        opencode_go_models = await refresh_opencode_go_models(working_config)
     except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
         logger.warning("Failed to refresh OpenCode Go models: {error}", error=exc)
-    if opencode_go_models and apply_opencode_go_models(config, opencode_go_models):
+    if opencode_go_models and apply_opencode_go_models(working_config, opencode_go_models):
         changed = True
 
     minimax_models: tuple[MiniMaxModel, ...] | None = None
+    minimax_snapshot = provider_snapshot(MINIMAX_ANTHROPIC_PROVIDER_KEY)
     try:
-        minimax_models = await refresh_minimax_models(config)
+        minimax_models = await refresh_minimax_models(working_config)
     except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
         logger.warning("Failed to refresh MiniMax models: {error}", error=exc)
-    if minimax_models is not None and apply_minimax_models(config, minimax_models):
+    if minimax_models is not None and apply_minimax_models(working_config, minimax_models):
         changed = True
 
     z_ai_results: dict[ZaiRoute, ZaiCatalogResult] = {}
+    z_ai_snapshots: dict[ZaiRoute, dict[str, LLMProvider | None]] = {}
     for route in ZAI_ROUTES:
+        route_snapshot = provider_snapshot(route.provider_key)
         try:
-            result = await refresh_z_ai_models(config, route)
+            result = await refresh_z_ai_models(working_config, route)
         except Exception as exc:
             logger.warning(
                 "Unexpected Z.AI catalog refresh failure for {route}: {error_type}",
@@ -477,9 +509,10 @@ async def refresh_managed_models(config: Config) -> bool:
             )
             continue
         z_ai_results[route] = result
+        z_ai_snapshots[route] = route_snapshot
         if result.status == "live":
             assert result.models is not None
-            if apply_z_ai_models(config, route, result.models):
+            if apply_z_ai_models(working_config, route, result.models):
                 changed = True
         elif result.status != "unconfigured":
             logger.warning(
@@ -490,33 +523,44 @@ async def refresh_managed_models(config: Config) -> bool:
             )
 
     kimi_models: tuple[KimiModel, ...] | None = None
+    kimi_snapshot = provider_snapshot(KIMI_PROVIDER_KEY)
     try:
-        kimi_models = await refresh_kimi_models(config)
+        kimi_models = await refresh_kimi_models(working_config)
     except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
         logger.warning("Failed to refresh Kimi models: {error}", error=exc)
-    if kimi_models is not None and apply_kimi_models(config, kimi_models):
+    if kimi_models is not None and apply_kimi_models(working_config, kimi_models):
         changed = True
 
-    if changed:
-        config_for_save = load_config()
-        save_changed = False
-        for provider_key, platform_id, models in updates:
-            if _apply_models(config_for_save, provider_key, platform_id, models):
-                save_changed = True
-        if opencode_go_models and apply_opencode_go_models(config_for_save, opencode_go_models):
-            save_changed = True
-        if minimax_models is not None and apply_minimax_models(config_for_save, minimax_models):
-            save_changed = True
-        for route, result in z_ai_results.items():
-            if result.status != "live":
-                continue
-            assert result.models is not None
-            if apply_z_ai_models(config_for_save, route, result.models):
-                save_changed = True
-        if kimi_models is not None and apply_kimi_models(config_for_save, kimi_models):
-            save_changed = True
-        if save_changed:
-            save_config(config_for_save)
+    has_collected_updates = (
+        bool(updates)
+        or bool(opencode_go_models)
+        or minimax_models is not None
+        or any(result.status == "live" for result in z_ai_results.values())
+        or kimi_models is not None
+    )
+    if has_collected_updates:
+        from pythinker_code.auth.oauth import persist_config_change
+
+        def apply_updates(committed: Config) -> None:
+            for provider_key, platform_id, models, expected_providers in updates:
+                if not providers_match(committed, expected_providers):
+                    continue
+                _apply_models(committed, provider_key, platform_id, models)
+            if opencode_go_models and providers_match(committed, opencode_go_snapshot):
+                apply_opencode_go_models(committed, opencode_go_models)
+            if minimax_models is not None and providers_match(committed, minimax_snapshot):
+                apply_minimax_models(committed, minimax_models)
+            for route, result in z_ai_results.items():
+                if result.status != "live":
+                    continue
+                if not providers_match(committed, z_ai_snapshots[route]):
+                    continue
+                assert result.models is not None
+                apply_z_ai_models(committed, route, result.models)
+            if kimi_models is not None and providers_match(committed, kimi_snapshot):
+                apply_kimi_models(committed, kimi_models)
+
+        await persist_config_change(config, apply_updates)
     return changed
 
 

--- a/src/pythinker_code/auth/platforms.py
+++ b/src/pythinker_code/auth/platforms.py
@@ -357,7 +357,22 @@ async def refresh_managed_models(config: Config) -> bool:
             # Construct off the event loop: OAuthManager.__init__ can run
             # _migrate_oauth_storage(), which takes a synchronous cross-process
             # file lock (5s timeout) and would otherwise stall async refresh.
-            oauth_manager = await asyncio.to_thread(OAuthManager, working_config)
+            # The worker thread cannot be cancelled, so on cancellation drain it
+            # to completion before unwinding — otherwise the migration could keep
+            # writing shared OAuth state (and hold its file lock) after the caller
+            # has gone.
+            worker = asyncio.create_task(asyncio.to_thread(OAuthManager, working_config))
+            try:
+                oauth_manager = await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                while not worker.done():
+                    try:
+                        await asyncio.shield(worker)
+                    except asyncio.CancelledError:
+                        continue
+                    except Exception:
+                        break
+                raise
         provider = working_config.providers.get(provider_key)
         if provider is None:
             continue

--- a/src/pythinker_code/auth/platforms.py
+++ b/src/pythinker_code/auth/platforms.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any, NamedTuple, cast
 
@@ -353,7 +354,10 @@ async def refresh_managed_models(config: Config) -> bool:
         if provider.oauth and oauth_manager is None:
             from pythinker_code.auth.oauth import OAuthManager
 
-            oauth_manager = OAuthManager(working_config)
+            # Construct off the event loop: OAuthManager.__init__ can run
+            # _migrate_oauth_storage(), which takes a synchronous cross-process
+            # file lock (5s timeout) and would otherwise stall async refresh.
+            oauth_manager = await asyncio.to_thread(OAuthManager, working_config)
         provider = working_config.providers.get(provider_key)
         if provider is None:
             continue

--- a/src/pythinker_code/auth/snowflake.py
+++ b/src/pythinker_code/auth/snowflake.py
@@ -21,7 +21,6 @@ from pythinker_code.auth.oauth import (
     OAuthEvent,
     OAuthToken,
     OAuthUnauthorized,
-    persist_config_change,
     persist_login,
     persist_logout,
 )
@@ -108,7 +107,7 @@ def _headers() -> dict[str, str]:
 
 
 def _inject_default_expiry(payload: dict[str, Any]) -> dict[str, Any]:
-    if not payload.get("expires_in"):
+    if payload.get("expires_in") is None:
         payload["expires_in"] = _DEFAULT_EXPIRES_IN
     return payload
 
@@ -307,11 +306,11 @@ async def login_snowflake(
             auth.code_verifier,
             auth.redirect_uri,
         )
+        token = OAuthToken.from_response(payload)
     except OAuthError as exc:
         yield OAuthEvent("error", f"Snowflake Cortex browser login failed: {exc}")
         return
 
-    token = OAuthToken.from_response(payload)
     if not token.refresh_token:
         yield OAuthEvent(
             "error",
@@ -327,6 +326,7 @@ async def login_snowflake(
             _oauth_ref(account),
             token,
             lambda cfg: _apply_snowflake_config(cfg, account, models),
+            replace_provider_key=SNOWFLAKE_PROVIDER_KEY,
         )
     except Exception as exc:
         logger.warning("Failed to persist Snowflake Cortex login: {exc}", exc=exc)
@@ -349,9 +349,6 @@ async def logout_snowflake(config: Config) -> AsyncIterator[OAuthEvent]:
         )
         return
 
-    provider = config.providers.get(SNOWFLAKE_PROVIDER_KEY)
-    ref = provider.oauth if provider is not None and provider.oauth is not None else None
-
     def _remove(cfg: Config) -> None:
         cfg.providers.pop(SNOWFLAKE_PROVIDER_KEY, None)
         for alias, model in list(cfg.models.items()):
@@ -361,10 +358,12 @@ async def logout_snowflake(config: Config) -> AsyncIterator[OAuthEvent]:
             cfg.default_model = next(iter(cfg.models), "")
 
     try:
-        if ref is not None:
-            await persist_logout(config, ref, _remove)
-        else:
-            await persist_config_change(config, _remove)
+        await persist_logout(
+            config,
+            None,
+            _remove,
+            provider_key=SNOWFLAKE_PROVIDER_KEY,
+        )
     except Exception as exc:
         logger.warning("Failed to persist Snowflake Cortex logout: {exc}", exc=exc)
         yield OAuthEvent("error", "Failed to log out of Snowflake Cortex.")

--- a/src/pythinker_code/auth/xai.py
+++ b/src/pythinker_code/auth/xai.py
@@ -231,11 +231,11 @@ async def login_xai_browser(
             auth.code_verifier,
             auth.redirect_uri,
         )
+        token = OAuthToken.from_response(payload)
     except OAuthError as exc:
         yield OAuthEvent("error", f"xAI Grok browser login failed: {exc}")
         return
 
-    token = OAuthToken.from_response(payload)
     if not token.refresh_token:
         yield OAuthEvent(
             "error",

--- a/src/pythinker_code/ui/shell/visualize/_interactive.py
+++ b/src/pythinker_code/ui/shell/visualize/_interactive.py
@@ -246,8 +246,11 @@ class _PromptLiveView(_LiveView):
         output = getattr(app, "output", None)
         if output is None or not getattr(output, "responds_to_cpr", False):
             return
-        with suppress(Exception):
+        try:
             await app.renderer.wait_for_cpr_responses()
+        except Exception as exc:  # noqa: BLE001 — settling is best-effort, must not break cleanup
+            _handoff_trace(f"CPR_SETTLE_FAIL\t{type(exc).__name__}:{exc}")
+            logger.debug("CPR settle failed after scrollback handoff: {}", exc)
 
     def _defer_scrollback_handoff(self) -> bool:
         """Backpressure: defer permanent scrollback while preamble geometry is unstable."""

--- a/src/pythinker_code/ui/shell/visualize/_interactive.py
+++ b/src/pythinker_code/ui/shell/visualize/_interactive.py
@@ -232,6 +232,23 @@ class _PromptLiveView(_LiveView):
         else:
             _handoff_trace(f"RENDERER_RESET\t{reason}")
 
+    async def _settle_cursor_after_handoff(self) -> None:
+        """Await the absolute-cursor CPR that ``run_in_terminal`` re-requests on
+        teardown, so a following live re-expansion diffs against a settled cursor
+        model instead of a provisional one. No-op on outputs without CPR support
+        (piped, legacy Win32); never raises — settling is best-effort and must not
+        break handoff cleanup."""
+        from prompt_toolkit.application import get_app_or_none
+
+        app = get_app_or_none()
+        if app is None:
+            return
+        output = getattr(app, "output", None)
+        if output is None or not getattr(output, "responds_to_cpr", False):
+            return
+        with suppress(Exception):
+            await app.renderer.wait_for_cpr_responses()
+
     def _defer_scrollback_handoff(self) -> bool:
         """Backpressure: defer permanent scrollback while preamble geometry is unstable."""
         return self._resize_recovery_remaining > 0
@@ -280,6 +297,15 @@ class _PromptLiveView(_LiveView):
             self._reset_prompt_renderer("handoff-fail")
             raise
         finally:
+            # run_in_terminal re-requests an absolute cursor position (an async
+            # CPR round-trip) on teardown. Let it settle while the multi-row body
+            # is still suppressed (depth > 0) so the body re-expands against a
+            # correct cursor model, not the provisional one — the window that
+            # otherwise strands the old rows as a doubled/ghosted block. Unlike a
+            # renderer reset, this touches no static scrollback, so it cannot
+            # re-fossilize committed content (regression-safe vs the queued-input
+            # ghost fix).
+            await self._settle_cursor_after_handoff()
             self._scrollback_handoff_depth -= 1
             self._safe_prompt_invalidate()
 

--- a/src/pythinker_code/utils/io.py
+++ b/src/pythinker_code/utils/io.py
@@ -1,42 +1,60 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import json
 import os
 import tempfile
+import time
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
 
+class FileLockTimeoutError(TimeoutError):
+    """An advisory file lock could not be acquired within its deadline."""
+
+
 @contextlib.contextmanager
-def file_lock(path: Path) -> Generator[None]:
+def file_lock(path: Path, *, timeout: float | None = None) -> Generator[None]:
     """Cross-process exclusive lock for read-modify-write cycles on *path*.
 
     ``atomic_json_write`` prevents torn files but not lost updates: two processes
     that both load before either saves drop each other's changes. Wrap the whole
     load → mutate → save in this lock to serialize concurrent writers. The lock
     file (``<path>.lock``) is kept on disk — unlinking would split the lock across
-    inodes. This call blocks; event-loop callers must run it via ``asyncio.to_thread``.
+    inodes. By default this call blocks indefinitely. Pass ``timeout`` for a
+    bounded wait; event-loop callers must run either form via ``asyncio.to_thread``.
     """
+    if timeout is not None and timeout < 0:
+        raise ValueError("File lock timeout must be non-negative.")
+
     lock_file = path.with_name(path.name + ".lock")
     lock_file.parent.mkdir(parents=True, exist_ok=True)
     fh = lock_file.open("a+b")
     try:
         if os.name == "nt":
             import msvcrt
-            import time
 
             if os.fstat(fh.fileno()).st_size == 0:
                 fh.write(b"\0")
                 fh.flush()
+            deadline = time.monotonic() + timeout if timeout is not None else None
             while True:
                 try:
                     fh.seek(0)
                     msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
                     break
-                except OSError:
-                    time.sleep(0.05)
+                except OSError as exc:
+                    if deadline is not None:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise FileLockTimeoutError(
+                                "Timed out waiting for an advisory file lock."
+                            ) from exc
+                        time.sleep(min(0.05, remaining))
+                    else:
+                        time.sleep(0.05)
             try:
                 yield
             finally:
@@ -46,7 +64,23 @@ def file_lock(path: Path) -> Generator[None]:
         else:
             import fcntl
 
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            if timeout is None:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            else:
+                deadline = time.monotonic() + timeout
+                while True:
+                    try:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        break
+                    except OSError as exc:
+                        if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                            raise
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise FileLockTimeoutError(
+                                "Timed out waiting for an advisory file lock."
+                            ) from exc
+                        time.sleep(min(0.05, remaining))
             try:
                 yield
             finally:

--- a/src/pythinker_code/web/api/sessions.py
+++ b/src/pythinker_code/web/api/sessions.py
@@ -877,7 +877,8 @@ async def generate_session_title(
 
             if provider_config:
                 oauth = OAuthManager(config)
-                await oauth.ensure_fresh()
+                if provider_config.oauth is not None:
+                    await oauth.ensure_fresh(oauth_ref=provider_config.oauth)
                 llm = create_llm(provider_config, model_config, oauth=oauth)
 
                 if llm:

--- a/tests/auth/test_digitalocean_auth.py
+++ b/tests/auth/test_digitalocean_auth.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 import pytest
@@ -58,6 +60,23 @@ class _RaisingRouterSession:
 
     def get(self, url: str, *, headers: Mapping[str, str]) -> object:
         raise self.exc
+
+
+class _CallbackWriter:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
 
 
 def test_apply_digitalocean_config_writes_provider_models_and_default() -> None:
@@ -128,7 +147,7 @@ async def test_fetch_router_catalog_returns_ok_with_names(
     calls: list[tuple[str, Mapping[str, str]]] = []
     response = _RouterResponse(
         200,
-        {"model_routers": [{"name": "primary"}, {"name": "fallback"}, {"no_name": 1}]},
+        {"model_routers": [{"name": "primary"}, {"name": "fallback"}]},
     )
     monkeypatch.setattr(do, "new_client_session", lambda: _RouterSession(response, calls))
 
@@ -140,12 +159,70 @@ async def test_fetch_router_catalog_returns_ok_with_names(
     assert calls[0][1]["Authorization"] == "Bearer tok"
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected_status", "expected_names"),
+    [
+        ({"model_routers": []}, "EMPTY", ()),
+        (
+            {"model_routers": [{"name": ""}, {"missing_name": True}, "invalid"]},
+            "MALFORMED",
+            (),
+        ),
+        (
+            {"model_routers": [{"name": "primary"}, {"missing_name": True}]},
+            "PARTIAL",
+            ("primary",),
+        ),
+        (
+            {"model_routers": [{"name": "   "}]},
+            "MALFORMED",
+            (),
+        ),
+        (
+            {"model_routers": [{"name": "primary"}, {"name": "   "}]},
+            "PARTIAL",
+            ("primary",),
+        ),
+        (
+            {"model_routers": [{"name": "primary"}, {"name": "fallback"}]},
+            "OK",
+            ("primary", "fallback"),
+        ),
+        (
+            {"model_routers": [{"name": "  primary router  "}]},
+            "OK",
+            ("  primary router  ",),
+        ),
+    ],
+    ids=(
+        "empty",
+        "all-invalid",
+        "mixed",
+        "all-whitespace",
+        "mixed-whitespace",
+        "all-valid",
+        "valid-name-preserved",
+    ),
+)
+def test_parse_router_names_distinguishes_entry_validity(
+    payload: object,
+    expected_status: str,
+    expected_names: tuple[str, ...],
+) -> None:
+    from pythinker_code.auth import digitalocean as do
+
+    catalog = do._parse_router_names(payload)
+
+    assert catalog.status.name == expected_status
+    assert catalog.names == expected_names
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("response", "expected"),
     [
         (_RouterResponse(200, {"model_routers": []}), "EMPTY"),
-        (_RouterResponse(200, {"model_routers": [{"no_name": 1}]}), "EMPTY"),
+        (_RouterResponse(200, {"model_routers": [{"no_name": 1}]}), "MALFORMED"),
         (_RouterResponse(401, {"id": "unauthorized"}), "UNAUTHORIZED"),
         (_RouterResponse(403, {"id": "forbidden"}), "UNAUTHORIZED"),
         (_RouterResponse(500, {"id": "server_error"}), "UNAVAILABLE"),
@@ -184,6 +261,32 @@ async def test_fetch_router_catalog_treats_transport_errors_as_unavailable(
     assert catalog.status is do.RouterDiscovery.UNAVAILABLE
 
 
+@pytest.mark.parametrize(
+    ("status_name", "expected_message"),
+    [
+        (
+            "PARTIAL",
+            "DigitalOcean returned some malformed inference-router entries; sign-in saved "
+            "with valid routers configured and malformed entries ignored.",
+        ),
+        (
+            "MALFORMED",
+            "DigitalOcean returned entirely malformed inference-router data; sign-in saved "
+            "with no models configured.",
+        ),
+    ],
+)
+def test_router_status_message_distinguishes_partial_and_malformed_data(
+    status_name: str,
+    expected_message: str,
+) -> None:
+    from pythinker_code.auth import digitalocean as do
+
+    status = do.RouterDiscovery[status_name]
+
+    assert do._router_status_message(status) == expected_message
+
+
 @pytest.mark.asyncio
 async def test_login_digitalocean_saves_discovered_routers_without_leaking_token(
     monkeypatch: pytest.MonkeyPatch,
@@ -211,6 +314,142 @@ async def test_login_digitalocean_saves_discovered_routers_without_leaking_token
     assert provider.api_key.get_secret_value() == access_token
     assert access_token not in "\n".join(f"{event!r}\n{event.json}" for event in events)
     assert (tmp_path / "config.toml").exists()
+
+
+@pytest.mark.asyncio
+async def test_login_digitalocean_rejects_blank_callback_token_without_persisting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from pythinker_code.auth import digitalocean as do
+    from pythinker_code.auth.oauth_flows import (
+        ImplicitAuthorization,
+        _handle_implicit_loopback_callback,
+    )
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    config = Config(is_from_default_location=True)
+    catalog_tokens: list[str] = []
+
+    async def blank_implicit_flow(**_kwargs: Any) -> ImplicitAuthorization:
+        result: asyncio.Future[ImplicitAuthorization] = asyncio.get_running_loop().create_future()
+        payload = bytes(
+            json.dumps({"access_token": "   ", "state": "expected-state"}),
+            encoding="utf-8",
+        )
+        request = bytes(
+            f"POST /auth/token HTTP/1.1\r\nContent-Length: {len(payload)}\r\n\r\n",
+            encoding="utf-8",
+        )
+        reader = asyncio.StreamReader()
+        reader.feed_data(request + payload)
+        reader.feed_eof()
+        await _handle_implicit_loopback_callback(
+            reader,
+            cast("asyncio.StreamWriter", _CallbackWriter()),
+            callback_path="/auth/callback",
+            token_path="/auth/token",
+            expected_state="expected-state",
+            result=result,
+        )
+        return await result
+
+    async def track_catalog(access_token: str) -> do.RouterCatalog:
+        catalog_tokens.append(access_token)
+        return do.RouterCatalog(do.RouterDiscovery.EMPTY, ())
+
+    monkeypatch.setattr(do, "run_loopback_implicit_flow", blank_implicit_flow)
+    monkeypatch.setattr(do, "_fetch_router_catalog", track_catalog)
+
+    events = [event async for event in do.login_digitalocean(config)]
+
+    assert [event.type for event in events] == ["waiting", "error"]
+    assert events[-1].message == (
+        "DigitalOcean browser login failed: OAuth callback did not include an access token."
+    )
+    assert catalog_tokens == []
+    assert do.DIGITALOCEAN_PROVIDER_KEY not in config.providers
+    assert not (tmp_path / "config.toml").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("router_payload", "expected_info", "expected_models", "expected_success"),
+    [
+        (
+            {
+                "model_routers": [
+                    {"name": ""},
+                    {"unexpected": "malformed-entry-secret"},
+                ]
+            },
+            "DigitalOcean returned entirely malformed inference-router data; sign-in saved "
+            "with no models configured.",
+            set(),
+            "DigitalOcean credentials saved; no inference routers are configured.",
+        ),
+        (
+            {
+                "model_routers": [
+                    {"name": "primary"},
+                    {"unexpected": "malformed-entry-secret"},
+                ]
+            },
+            "DigitalOcean returned some malformed inference-router entries; sign-in saved "
+            "with valid routers configured and malformed entries ignored.",
+            {"digitalocean/router:primary"},
+            "DigitalOcean configured with model digitalocean/router:primary.",
+        ),
+        (
+            {"model_routers": [{"name": "   "}]},
+            "DigitalOcean returned entirely malformed inference-router data; sign-in saved "
+            "with no models configured.",
+            set(),
+            "DigitalOcean credentials saved; no inference routers are configured.",
+        ),
+        (
+            {"model_routers": [{"name": "primary"}, {"name": "   "}]},
+            "DigitalOcean returned some malformed inference-router entries; sign-in saved "
+            "with valid routers configured and malformed entries ignored.",
+            {"digitalocean/router:primary"},
+            "DigitalOcean configured with model digitalocean/router:primary.",
+        ),
+    ],
+    ids=("all-invalid", "mixed", "all-whitespace", "mixed-whitespace"),
+)
+async def test_login_digitalocean_reports_malformed_router_entries_safely(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    router_payload: object,
+    expected_info: str,
+    expected_models: set[str],
+    expected_success: str,
+) -> None:
+    from pythinker_code.auth import digitalocean as do
+    from pythinker_code.auth.oauth_flows import ImplicitAuthorization
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    config = Config(is_from_default_location=True)
+
+    async def fake_implicit_flow(**_kwargs: Any) -> ImplicitAuthorization:
+        return ImplicitAuthorization("access-token", None, "state")
+
+    response = _RouterResponse(200, router_payload)
+    monkeypatch.setattr(do, "run_loopback_implicit_flow", fake_implicit_flow)
+    monkeypatch.setattr(do, "new_client_session", lambda: _RouterSession(response, []))
+
+    events = [event async for event in do.login_digitalocean(config)]
+
+    assert [event.type for event in events] == ["waiting", "info", "success"]
+    assert events[1].message == expected_info
+    assert events[-1].message == expected_success
+    configured_models = {
+        alias
+        for alias, model in config.models.items()
+        if model.provider == do.DIGITALOCEAN_PROVIDER_KEY
+    }
+    assert configured_models == expected_models
+    assert "malformed-entry-secret" not in "\n".join(event.json for event in events)
 
 
 @pytest.mark.asyncio

--- a/tests/auth/test_oauth_cross_process.py
+++ b/tests/auth/test_oauth_cross_process.py
@@ -121,7 +121,7 @@ def test_atomic_save_no_corruption(tmp_path: Path) -> None:
                 token_type="Bearer",
                 expires_in=900.0,
             )
-            _save_to_file("pythinker-code", token)
+            _save_to_file("oauth/pythinker-code", token)
 
         # After all writes, the file must still be valid JSON.
         path = Path({str(tmp_path / "share" / "credentials" / "pythinker-code.json")!r})

--- a/tests/auth/test_oauth_flows.py
+++ b/tests/auth/test_oauth_flows.py
@@ -323,6 +323,34 @@ async def _drive_implicit_handler(
     return result, writer
 
 
+async def _drive_implicit_content_length(
+    content_length: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[asyncio.Future[ImplicitAuthorization], _FakeWriter, list[int]]:
+    result: asyncio.Future[ImplicitAuthorization] = asyncio.get_running_loop().create_future()
+    writer = _FakeWriter()
+    request = (
+        f"POST /oauth/token HTTP/1.1\r\nHost: localhost\r\nContent-Length: {content_length}\r\n\r\n"
+    )
+    reader = _request_reader(request)
+    read_sizes: list[int] = []
+
+    async def track_readexactly(size: int) -> bytes:
+        read_sizes.append(size)
+        return b"{}"
+
+    monkeypatch.setattr(reader, "readexactly", track_readexactly)
+    await _handle_implicit_loopback_callback(
+        reader,
+        cast("asyncio.StreamWriter", writer),
+        callback_path="/oauth/callback",
+        token_path="/oauth/token",
+        expected_state="expected-state",
+        result=result,
+    )
+    return result, writer, read_sizes
+
+
 def _mock_loopback_server(
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[
@@ -491,8 +519,11 @@ async def test_implicit_callback_rejects_wrong_state_before_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_implicit_callback_requires_access_token() -> None:
-    result, writer = await _drive_implicit_handler({"access_token": "", "state": "expected-state"})
+@pytest.mark.parametrize("access_token", ["", "   ", "\t\r\n"])
+async def test_implicit_callback_requires_nonblank_access_token(access_token: str) -> None:
+    result, writer = await _drive_implicit_handler(
+        {"access_token": access_token, "state": "expected-state"}
+    )
 
     with pytest.raises(OAuthError):
         _ = await result
@@ -538,6 +569,42 @@ async def test_implicit_callback_rejects_truncated_body() -> None:
     with pytest.raises(OAuthError):
         _ = await result
     assert bytes(writer.buffer).startswith(b"HTTP/1.1 400 Bad Request")
+
+
+@pytest.mark.asyncio
+async def test_implicit_callback_rejects_oversized_body_before_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, writer, read_sizes = await _drive_implicit_content_length("65537", monkeypatch)
+
+    with pytest.raises(OAuthError, match="^OAuth callback body exceeded the size limit\\.$"):
+        _ = await result
+    assert bytes(writer.buffer).startswith(b"HTTP/1.1 413 Payload Too Large")
+    assert read_sizes == []
+
+
+@pytest.mark.asyncio
+async def test_implicit_callback_rejects_negative_content_length_before_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, writer, read_sizes = await _drive_implicit_content_length("-1", monkeypatch)
+
+    with pytest.raises(OAuthError, match="^OAuth callback Content-Length was invalid\\.$"):
+        _ = await result
+    assert bytes(writer.buffer).startswith(b"HTTP/1.1 400 Bad Request")
+    assert read_sizes == []
+
+
+@pytest.mark.asyncio
+async def test_implicit_callback_rejects_malformed_content_length_before_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, writer, read_sizes = await _drive_implicit_content_length("1_0", monkeypatch)
+
+    with pytest.raises(OAuthError, match="^OAuth callback Content-Length was invalid\\.$"):
+        _ = await result
+    assert bytes(writer.buffer).startswith(b"HTTP/1.1 400 Bad Request")
+    assert read_sizes == []
 
 
 @pytest.mark.asyncio

--- a/tests/auth/test_oauth_persist.py
+++ b/tests/auth/test_oauth_persist.py
@@ -511,6 +511,49 @@ async def test_replacement_with_same_credential_key_keeps_new_token(
     assert caller == committed
 
 
+def test_credential_transaction_locks_are_reentrant_same_thread(tmp_path, monkeypatch) -> None:
+    """A thread already holding a credential key's lock can re-enter it without
+    deadlocking — fcntl.flock / msvcrt.locking deny a second same-file
+    acquisition within one process, so reentrancy is tracked in Python. Guards
+    the keyring-migration self-deadlock (load_tokens inside a persist transaction).
+    """
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    key = "oauth/reentrant-provider"
+    counts = oauth._held_credential_key_counts()
+    assert counts.get(key, 0) == 0
+    with oauth._credential_transaction_locks([key]):
+        assert counts.get(key, 0) == 1
+        with oauth._credential_transaction_locks([key]):
+            # Reentrant no-op acquisition; must not block on the same file lock.
+            assert counts.get(key, 0) == 2
+        # Inner exit decrements but the outer hold (and OS lock) remains.
+        assert counts.get(key, 0) == 1
+    assert counts.get(key, 0) == 0
+
+
+def test_load_tokens_keyring_migration_reentrant_under_held_lock(tmp_path, monkeypatch) -> None:
+    """The keyring read-copy-delete migration in load_tokens() is serialized under
+    the credential lock (so it cannot race persist), and re-enters safely when the
+    caller already holds that key's lock (the persist_login -> load_tokens path).
+    Pre-fix this path self-deadlocked on the non-reentrant cross-process lock.
+    """
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    key = "oauth/keyring-migrate"
+    migrated_token = _token("keyring-access", "keyring-refresh")
+    monkeypatch.setattr(oauth, "_load_from_keyring", lambda _k: migrated_token)
+    deleted: list[str] = []
+    monkeypatch.setattr(oauth, "_delete_from_keyring", deleted.append)
+    ref = OAuthRef(storage="keyring", key=key)
+
+    with oauth._credential_transaction_locks([key]):
+        result = oauth.load_tokens(ref)  # would self-deadlock without reentrancy
+
+    assert result == migrated_token
+    assert deleted == [key]  # keyring entry removed as part of the migration
+    # Token now lives on the authoritative file copy.
+    assert oauth.load_tokens(OAuthRef(storage="file", key=key)) == migrated_token
+
+
 @pytest.mark.asyncio
 async def test_old_token_rollback_failure_preserves_committed_new_pair(
     monkeypatch: pytest.MonkeyPatch, tmp_path

--- a/tests/auth/test_oauth_persist.py
+++ b/tests/auth/test_oauth_persist.py
@@ -8,14 +8,26 @@ credential (only a fresh login with no prior token deletes on failure).
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
+import time
 from types import SimpleNamespace
 
+import keyring.errors
 import pytest
+from pydantic import SecretStr
 
 from pythinker_code.auth import oauth
 from pythinker_code.auth.oauth import OAuthToken
-from pythinker_code.config import Config, OAuthRef
+from pythinker_code.config import (
+    Config,
+    LLMProvider,
+    OAuthRef,
+    get_config_file,
+    load_config,
+    save_config,
+)
+from pythinker_code.utils.io import file_lock
 
 
 def _token(access: str, refresh: str) -> OAuthToken:
@@ -26,6 +38,699 @@ def _token(access: str, refresh: str) -> OAuthToken:
         scope="test-scope",
         token_type="Bearer",
     )
+
+
+def _provider(name: str, *, oauth_ref: OAuthRef | None = None) -> LLMProvider:
+    return LLMProvider(
+        type="openai_legacy",
+        base_url=f"https://{name}.example/v1",
+        api_key=SecretStr(""),
+        oauth=oauth_ref,
+    )
+
+
+def _stale_caller_with_authoritative_provider() -> tuple[Config, Config, Config]:
+    save_config(Config(is_from_default_location=True))
+    caller = load_config(get_config_file())
+    caller_before = caller.model_copy(deep=True)
+    authoritative = load_config(get_config_file())
+    authoritative.providers["managed:authoritative"] = _provider("authoritative")
+    save_config(authoritative)
+    return caller, caller_before, authoritative
+
+
+@pytest.mark.asyncio
+async def test_persistence_config_lock_contention_is_bounded_and_safe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    save_config(Config(is_from_default_location=True))
+    ref = OAuthRef(storage="file", key="oauth/contended-provider")
+    lock_entered = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_config_lock() -> None:
+        with file_lock(get_config_file()):
+            lock_entered.set()
+            if not release_lock.wait(timeout=5):
+                raise TimeoutError("config-lock test barrier timed out")
+
+    holder = threading.Thread(target=hold_config_lock)
+    holder.start()
+    assert lock_entered.wait(timeout=5)
+    monkeypatch.setattr(oauth, "_PERSISTENCE_LOCK_TIMEOUT_SECONDS", 0.05, raising=False)
+    timer = threading.Timer(0.5, release_lock.set)
+    timer.start()
+
+    started = time.monotonic()
+    try:
+        with pytest.raises(oauth.OAuthPersistenceError) as caught:
+            await oauth.persist_login(
+                Config(is_from_default_location=True),
+                ref,
+                _token("new-access", "new-refresh"),
+                lambda cfg: cfg.providers.__setitem__(
+                    "managed:contended-provider", _provider("contended", oauth_ref=ref)
+                ),
+            )
+    finally:
+        release_lock.set()
+        timer.cancel()
+        holder.join(timeout=5)
+
+    assert time.monotonic() - started < 0.4
+    assert str(tmp_path) not in str(caught.value)
+    assert oauth.load_tokens(ref) is None
+    assert "managed:contended-provider" not in load_config(get_config_file()).providers
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_persistence_mutation_aborts_worker_without_side_effects(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    save_config(Config(is_from_default_location=True))
+    ref = OAuthRef(storage="file", key="oauth/pre-mutation-cancel")
+    lock_entered = threading.Event()
+    release_lock = threading.Event()
+    apply_called = threading.Event()
+
+    def hold_config_lock() -> None:
+        with file_lock(get_config_file()):
+            lock_entered.set()
+            if not release_lock.wait(timeout=5):
+                raise TimeoutError("config-lock test barrier timed out")
+
+    holder = threading.Thread(target=hold_config_lock)
+    holder.start()
+    assert lock_entered.wait(timeout=5)
+
+    def apply_config(cfg: Config) -> None:
+        apply_called.set()
+        cfg.providers["managed:cancelled"] = _provider("cancelled", oauth_ref=ref)
+
+    task = asyncio.create_task(
+        oauth.persist_login(
+            Config(is_from_default_location=True),
+            ref,
+            _token("cancelled-access", "cancelled-refresh"),
+            apply_config,
+        )
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.sleep(0.05)
+    completed_while_blocked = task.done()
+    release_lock.set()
+    holder.join(timeout=5)
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.to_thread(apply_called.wait, 0.5)
+
+    assert not completed_while_blocked
+    assert not apply_called.is_set()
+    assert oauth.load_tokens(ref) is None
+    assert "managed:cancelled" not in load_config(get_config_file()).providers
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_persistence_mutation_waits_for_atomic_completion(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    save_config(Config(is_from_default_location=True))
+    ref = OAuthRef(storage="file", key="oauth/post-mutation-cancel")
+    mutation_entered = threading.Event()
+    release_mutation = threading.Event()
+
+    def apply_config(cfg: Config) -> None:
+        cfg.providers["managed:completed"] = _provider("completed", oauth_ref=ref)
+        mutation_entered.set()
+        if not release_mutation.wait(timeout=5):
+            raise TimeoutError("mutation test barrier timed out")
+
+    task = asyncio.create_task(
+        oauth.persist_login(
+            Config(is_from_default_location=True),
+            ref,
+            _token("completed-access", "completed-refresh"),
+            apply_config,
+        )
+    )
+    assert await asyncio.to_thread(mutation_entered.wait, 5)
+    task.cancel()
+    await asyncio.sleep(0.05)
+    completed_while_mutating = task.done()
+    release_mutation.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    committed = load_config(get_config_file())
+    stored = oauth.load_tokens(ref)
+    assert not completed_while_mutating
+    assert "managed:completed" in committed.providers
+    assert stored is not None
+    assert stored.access_token == "completed-access"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_persistence_surfaces_worker_failure_with_both_causes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    save_config(Config(is_from_default_location=True))
+    ref = OAuthRef(storage="file", key="oauth/cancelled-failure")
+    mutation_entered = threading.Event()
+    release_mutation = threading.Event()
+    sensitive_detail = f"disk failure at {tmp_path}"
+
+    def fail_apply(_config: Config) -> None:
+        mutation_entered.set()
+        if not release_mutation.wait(timeout=5):
+            raise TimeoutError("mutation test barrier timed out")
+        raise OSError(sensitive_detail)
+
+    task = asyncio.create_task(
+        oauth.persist_login(
+            Config(is_from_default_location=True),
+            ref,
+            _token("cancelled-access", "cancelled-refresh"),
+            fail_apply,
+        )
+    )
+    assert await asyncio.to_thread(mutation_entered.wait, 5)
+    task.cancel()
+    release_mutation.set()
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="cancellation") as caught:
+        await task
+
+    assert sensitive_detail not in str(caught.value)
+    assert str(tmp_path) not in str(caught.value)
+    causes = caught.value.__cause__
+    assert isinstance(causes, BaseExceptionGroup)
+    assert any(isinstance(exc, asyncio.CancelledError) for exc in causes.exceptions)
+    assert any(isinstance(exc, OSError) for exc in causes.exceptions)
+    assert oauth.load_tokens(ref) is None
+    assert load_config(get_config_file()).providers == {}
+
+
+@pytest.mark.asyncio
+async def test_login_and_logout_fail_closed_on_shared_credential_lock(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    monkeypatch.setattr(oauth, "_CROSS_PROCESS_LOCK_RETRIES", 0)
+    ref = OAuthRef(storage="file", key="oauth/shared-lock")
+    provider_key = "managed:shared-lock"
+    initial = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("shared", oauth_ref=ref)},
+    )
+    save_config(initial)
+    oauth.save_tokens(ref, _token("old-access", "old-refresh"))
+    lock = oauth._CrossProcessLock(ref.key)
+    assert lock._acquire()
+
+    try:
+        with pytest.raises(oauth.OAuthPersistenceError, match="credential lock"):
+            await oauth.persist_login(
+                load_config(get_config_file()),
+                ref,
+                _token("new-access", "new-refresh"),
+                lambda cfg: cfg.providers.__setitem__(
+                    provider_key, _provider("new", oauth_ref=ref)
+                ),
+            )
+        with pytest.raises(oauth.OAuthPersistenceError, match="credential lock"):
+            await oauth.persist_logout(
+                load_config(get_config_file()),
+                ref,
+                lambda cfg: cfg.providers.__delitem__(provider_key),
+            )
+    finally:
+        lock.release()
+
+    committed = load_config(get_config_file())
+    stored = oauth.load_tokens(ref)
+    assert provider_key in committed.providers
+    assert stored is not None
+    assert stored.access_token == "old-access"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("old_key", "new_key", "expected_order"),
+    [
+        ("oauth/z-old", "oauth/a-new", ["oauth/a-new", "oauth/z-old"]),
+        ("oauth/shared", "oauth/shared", ["oauth/shared"]),
+    ],
+    ids=["sorted", "deduplicated"],
+)
+async def test_replacement_locks_old_and_new_credential_keys_in_sorted_order(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    old_key: str,
+    new_key: str,
+    expected_order: list[str],
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:replacement-order"
+    old_ref = OAuthRef(storage="file", key=old_key)
+    new_ref = OAuthRef(storage="file", key=new_key)
+    config = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("old", oauth_ref=old_ref)},
+    )
+    save_config(config)
+    oauth.save_tokens(old_ref, _token("old-access", "old-refresh"))
+    events: list[tuple[str, str]] = []
+
+    class RecordingLock:
+        def __init__(self, key: str) -> None:
+            self.key = key
+
+        def acquire_with_retry_sync(self) -> bool:
+            events.append(("acquire", self.key))
+            return True
+
+        def release(self) -> None:
+            events.append(("release", self.key))
+
+    monkeypatch.setattr(oauth, "_CrossProcessLock", RecordingLock)
+
+    await oauth.persist_login(
+        load_config(get_config_file()),
+        new_ref,
+        _token("new-access", "new-refresh"),
+        lambda cfg: cfg.providers.__setitem__(provider_key, _provider("new", oauth_ref=new_ref)),
+        replace_provider_key=provider_key,
+    )
+
+    assert [key for event, key in events if event == "acquire"] == expected_order
+    assert [key for event, key in events if event == "release"] == list(reversed(expected_order))
+
+
+@pytest.mark.asyncio
+async def test_persist_login_merges_stale_config_under_lock(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    save_config(Config(is_from_default_location=True))
+    first_config = load_config(get_config_file())
+    second_config = load_config(get_config_file())
+    first_ref = OAuthRef(storage="file", key="oauth/first-provider")
+    second_ref = OAuthRef(storage="file", key="oauth/second-provider")
+
+    await oauth.persist_login(
+        first_config,
+        first_ref,
+        _token("first-access", "first-refresh"),
+        lambda cfg: cfg.providers.__setitem__(
+            "managed:first-provider", _provider("first", oauth_ref=first_ref)
+        ),
+    )
+    await oauth.persist_login(
+        second_config,
+        second_ref,
+        _token("second-access", "second-refresh"),
+        lambda cfg: cfg.providers.__setitem__(
+            "managed:second-provider", _provider("second", oauth_ref=second_ref)
+        ),
+    )
+
+    committed = load_config(get_config_file())
+    assert set(committed.providers) == {
+        "managed:first-provider",
+        "managed:second-provider",
+    }
+    assert second_config == committed
+
+
+@pytest.mark.asyncio
+async def test_persist_config_change_merges_stale_config_under_lock(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    save_config(Config(is_from_default_location=True))
+    first_config = load_config(get_config_file())
+    second_config = load_config(get_config_file())
+
+    await oauth.persist_config_change(
+        first_config,
+        lambda cfg: cfg.providers.__setitem__("managed:first-provider", _provider("first")),
+    )
+    await oauth.persist_config_change(
+        second_config,
+        lambda cfg: cfg.providers.__setitem__("managed:second-provider", _provider("second")),
+    )
+
+    committed = load_config(get_config_file())
+    assert set(committed.providers) == {
+        "managed:first-provider",
+        "managed:second-provider",
+    }
+    assert second_config == committed
+
+
+@pytest.mark.asyncio
+async def test_failed_login_leaves_stale_caller_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    caller, caller_before, authoritative = _stale_caller_with_authoritative_provider()
+    ref = OAuthRef(storage="file", key="oauth/failed-provider")
+
+    def fail_config_save(_config: Config) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(oauth, "save_config", fail_config_save)
+
+    with pytest.raises(OSError, match="disk full"):
+        await oauth.persist_login(
+            caller,
+            ref,
+            _token("failed-access", "failed-refresh"),
+            lambda cfg: cfg.providers.__setitem__(
+                "managed:failed-provider", _provider("failed", oauth_ref=ref)
+            ),
+        )
+
+    assert caller == caller_before
+    assert load_config(get_config_file()) == authoritative
+
+
+@pytest.mark.asyncio
+async def test_replaced_credential_cleanup_failure_rolls_back_config_and_both_tokens(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:account-scoped"
+    old_ref = OAuthRef(storage="file", key="oauth/account-scoped/old")
+    new_ref = OAuthRef(storage="file", key="oauth/account-scoped/new")
+
+    save_config(Config(is_from_default_location=True))
+    caller = load_config(get_config_file())
+    caller_before = caller.model_copy(deep=True)
+    authoritative = load_config(get_config_file())
+    authoritative.providers[provider_key] = _provider("old", oauth_ref=old_ref)
+    save_config(authoritative)
+    oauth.save_tokens(old_ref, _token("old-access", "old-refresh"))
+    oauth.save_tokens(new_ref, _token("previous-new-access", "previous-new-refresh"))
+
+    original_delete_tokens = oauth.delete_tokens
+    deleted: list[OAuthRef] = []
+
+    def delete_then_fail(ref: OAuthRef) -> None:
+        original_delete_tokens(ref)
+        deleted.append(ref)
+        raise OSError("cleanup denied")
+
+    monkeypatch.setattr(oauth, "delete_tokens", delete_then_fail)
+
+    with pytest.raises(
+        oauth.OAuthPersistenceError,
+        match="credential cleanup failed; login was rolled back",
+    ):
+        await oauth.persist_login(
+            caller,
+            new_ref,
+            _token("attempted-access", "attempted-refresh"),
+            lambda cfg: cfg.providers.__setitem__(
+                provider_key, _provider("new", oauth_ref=new_ref)
+            ),
+            replace_provider_key=provider_key,
+        )
+
+    assert deleted == [old_ref]
+    assert load_config(get_config_file()) == authoritative
+    restored_old = oauth.load_tokens(old_ref)
+    restored_new = oauth.load_tokens(new_ref)
+    assert restored_old is not None
+    assert restored_old.access_token == "old-access"
+    assert restored_new is not None
+    assert restored_new.access_token == "previous-new-access"
+    assert caller == caller_before
+
+
+@pytest.mark.asyncio
+async def test_replacement_with_same_credential_key_keeps_new_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    monkeypatch.setattr(oauth, "_delete_from_keyring", lambda _key: None)
+    provider_key = "managed:account-scoped"
+    credential_key = "oauth/account-scoped/shared"
+    old_ref = OAuthRef(storage="keyring", key=credential_key)
+    new_ref = OAuthRef(storage="file", key=credential_key)
+    oauth.save_tokens(new_ref, _token("old-access", "old-refresh"))
+    authoritative = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("old", oauth_ref=old_ref)},
+    )
+    save_config(authoritative)
+    caller = load_config(get_config_file())
+
+    await oauth.persist_login(
+        caller,
+        new_ref,
+        _token("new-access", "new-refresh"),
+        lambda cfg: cfg.providers.__setitem__(provider_key, _provider("new", oauth_ref=new_ref)),
+        replace_provider_key=provider_key,
+    )
+
+    committed = load_config(get_config_file())
+    committed_ref = committed.providers[provider_key].oauth
+    assert committed_ref is not None
+    assert committed_ref == new_ref
+    stored = oauth.load_tokens(committed_ref)
+    assert stored is not None
+    assert stored.access_token == "new-access"
+    assert caller == committed
+
+
+@pytest.mark.asyncio
+async def test_old_token_rollback_failure_preserves_committed_new_pair(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:account-scoped"
+    old_ref = OAuthRef(storage="file", key="oauth/account-scoped/old")
+    new_ref = OAuthRef(storage="file", key="oauth/account-scoped/new")
+    save_config(Config(is_from_default_location=True))
+    caller = load_config(get_config_file())
+    caller_before = caller.model_copy(deep=True)
+    authoritative = load_config(get_config_file())
+    authoritative.providers[provider_key] = _provider("old", oauth_ref=old_ref)
+    save_config(authoritative)
+    oauth.save_tokens(old_ref, _token("old-access", "old-refresh"))
+
+    cleanup_diagnostic = "cleanup denied for old-secret"
+    rollback_diagnostic = "old token restore denied for old-secret"
+    original_delete_tokens = oauth.delete_tokens
+    original_save_tokens = oauth.save_tokens
+
+    def delete_old_then_fail(ref: OAuthRef) -> None:
+        original_delete_tokens(ref)
+        if ref.key == old_ref.key:
+            raise OSError(cleanup_diagnostic)
+
+    def fail_old_token_restore(ref: OAuthRef, token: OAuthToken) -> OAuthRef:
+        if ref.key == old_ref.key:
+            raise OSError(rollback_diagnostic)
+        return original_save_tokens(ref, token)
+
+    monkeypatch.setattr(oauth, "delete_tokens", delete_old_then_fail)
+    monkeypatch.setattr(oauth, "save_tokens", fail_old_token_restore)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        await oauth.persist_login(
+            caller,
+            new_ref,
+            _token("new-access", "new-refresh"),
+            lambda cfg: cfg.providers.__setitem__(
+                provider_key, _provider("new", oauth_ref=new_ref)
+            ),
+            replace_provider_key=provider_key,
+        )
+
+    assert cleanup_diagnostic not in str(caught.value)
+    assert rollback_diagnostic not in str(caught.value)
+    committed = load_config(get_config_file())
+    committed_ref = committed.providers[provider_key].oauth
+    assert committed_ref is not None
+    assert committed_ref == new_ref
+    stored = oauth.load_tokens(committed_ref)
+    assert stored is not None
+    assert stored.access_token == "new-access"
+    assert caller == caller_before
+    assert "replaced credential rollback also failed" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_config_rollback_failure_preserves_committed_new_pair(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:account-scoped"
+    old_ref = OAuthRef(storage="file", key="oauth/account-scoped/old")
+    new_ref = OAuthRef(storage="file", key="oauth/account-scoped/new")
+    save_config(Config(is_from_default_location=True))
+    caller = load_config(get_config_file())
+    caller_before = caller.model_copy(deep=True)
+    authoritative = load_config(get_config_file())
+    authoritative.providers[provider_key] = _provider("old", oauth_ref=old_ref)
+    save_config(authoritative)
+    oauth.save_tokens(old_ref, _token("old-access", "old-refresh"))
+
+    cleanup_diagnostic = "cleanup denied for old-secret"
+    rollback_diagnostic = "config restore denied for old-secret"
+    original_delete_tokens = oauth.delete_tokens
+    original_save_config = oauth.save_config
+    save_calls = 0
+
+    def delete_old_then_fail(ref: OAuthRef) -> None:
+        original_delete_tokens(ref)
+        if ref.key == old_ref.key:
+            raise OSError(cleanup_diagnostic)
+
+    def fail_config_rollback(config: Config) -> None:
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 2:
+            raise OSError(rollback_diagnostic)
+        original_save_config(config)
+
+    monkeypatch.setattr(oauth, "delete_tokens", delete_old_then_fail)
+    monkeypatch.setattr(oauth, "save_config", fail_config_rollback)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        await oauth.persist_login(
+            caller,
+            new_ref,
+            _token("new-access", "new-refresh"),
+            lambda cfg: cfg.providers.__setitem__(
+                provider_key, _provider("new", oauth_ref=new_ref)
+            ),
+            replace_provider_key=provider_key,
+        )
+
+    assert cleanup_diagnostic not in str(caught.value)
+    assert rollback_diagnostic not in str(caught.value)
+    committed = load_config(get_config_file())
+    committed_ref = committed.providers[provider_key].oauth
+    assert committed_ref is not None
+    assert committed_ref == new_ref
+    stored = oauth.load_tokens(committed_ref)
+    assert stored is not None
+    assert stored.access_token == "new-access"
+    restored_old = oauth.load_tokens(old_ref)
+    assert restored_old is not None
+    assert restored_old.access_token == "old-access"
+    assert caller == caller_before
+    assert "configuration rollback also failed" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_failed_config_change_leaves_stale_caller_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    caller, caller_before, authoritative = _stale_caller_with_authoritative_provider()
+
+    def fail_config_save(_config: Config) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(oauth, "save_config", fail_config_save)
+
+    with pytest.raises(OSError, match="disk full"):
+        await oauth.persist_config_change(
+            caller,
+            lambda cfg: cfg.providers.__setitem__("managed:failed", _provider("failed")),
+        )
+
+    assert caller == caller_before
+    assert load_config(get_config_file()) == authoritative
+
+
+@pytest.mark.asyncio
+async def test_failed_logout_rollback_leaves_stale_caller_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    caller, caller_before, _authoritative = _stale_caller_with_authoritative_provider()
+    ref = OAuthRef(storage="file", key="oauth/authoritative")
+    oauth.save_tokens(ref, _token("access", "refresh"))
+    original_save_config = oauth.save_config
+    save_calls = 0
+
+    def fail_config_rollback(config: Config) -> None:
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 2:
+            raise OSError("rollback denied")
+        original_save_config(config)
+
+    def fail_delete(_ref: OAuthRef) -> None:
+        raise OSError("delete denied")
+
+    def remove_authoritative(config: Config) -> None:
+        del config.providers["managed:authoritative"]
+
+    monkeypatch.setattr(oauth, "save_config", fail_config_rollback)
+    monkeypatch.setattr(oauth, "delete_tokens", fail_delete)
+
+    with pytest.raises(
+        oauth.OAuthPersistenceError,
+        match="configuration rollback also failed",
+    ):
+        await oauth.persist_logout(
+            caller,
+            ref,
+            remove_authoritative,
+        )
+
+    assert caller == caller_before
+
+
+@pytest.mark.asyncio
+async def test_persist_logout_resolves_authoritative_provider_credential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:account-scoped"
+    stale_ref = OAuthRef(storage="file", key="oauth/account-scoped/stale")
+    authoritative_ref = OAuthRef(storage="file", key="oauth/account-scoped/authoritative")
+    caller = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("stale", oauth_ref=stale_ref)},
+    )
+    authoritative = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("authoritative", oauth_ref=authoritative_ref)},
+    )
+    save_config(authoritative)
+    oauth.save_tokens(stale_ref, _token("stale-access", "stale-refresh"))
+    oauth.save_tokens(authoritative_ref, _token("authoritative-access", "authoritative-refresh"))
+
+    def remove_provider(config: Config) -> None:
+        config.providers.pop(provider_key, None)
+
+    await oauth.persist_logout(
+        caller,
+        stale_ref,
+        remove_provider,
+        provider_key=provider_key,
+    )
+
+    assert provider_key not in load_config(get_config_file()).providers
+    assert oauth.load_tokens(authoritative_ref) is None
+    stale_token = oauth.load_tokens(stale_ref)
+    assert stale_token is not None
+    assert stale_token.access_token == "stale-access"
+    assert caller == load_config(get_config_file())
 
 
 @pytest.mark.asyncio
@@ -264,15 +969,738 @@ async def test_persist_logout_surfaces_delete_failure_and_restores_config(
     assert saved_defaults == ["", "provider/model"]
 
 
+@pytest.mark.asyncio
+async def test_persist_logout_restores_deleted_credential_before_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:logout-rollback"
+    ref = OAuthRef(storage="file", key="oauth/logout-rollback")
+    original_token = _token("original-access", "original-refresh")
+    config = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("logout", oauth_ref=ref)},
+    )
+    save_config(config)
+    oauth.save_tokens(ref, original_token)
+    original_save_config = oauth.save_config
+    rollback_order_verified = False
+    sensitive_detail = f"delete backend failed at {tmp_path}"
+
+    def delete_then_raise(target_ref: OAuthRef) -> None:
+        oauth._delete_from_file(target_ref.key)
+        raise OSError(sensitive_detail)
+
+    def observe_config_save(candidate: Config) -> None:
+        nonlocal rollback_order_verified
+        if provider_key in candidate.providers:
+            assert oauth._load_from_file(ref.key) == original_token
+            rollback_order_verified = True
+        original_save_config(candidate)
+
+    monkeypatch.setattr(oauth, "delete_tokens", delete_then_raise)
+    monkeypatch.setattr(oauth, "save_config", observe_config_save)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="logout was rolled back") as caught:
+        await oauth.persist_logout(
+            config,
+            ref,
+            lambda cfg: cfg.providers.__delitem__(provider_key),
+        )
+
+    assert sensitive_detail not in str(caught.value)
+    assert provider_key in load_config(get_config_file()).providers
+    assert oauth._load_from_file(ref.key) == original_token
+    assert provider_key in config.providers
+    assert rollback_order_verified
+
+
+@pytest.mark.asyncio
+async def test_persist_logout_credential_restore_failure_keeps_logout_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:partial-logout"
+    ref = OAuthRef(storage="file", key="oauth/partial-logout")
+    config = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("partial", oauth_ref=ref)},
+    )
+    save_config(config)
+    oauth.save_tokens(ref, _token("original-access", "original-refresh"))
+    delete_detail = f"delete backend failed at {tmp_path}"
+    restore_detail = f"restore backend failed at {tmp_path}"
+
+    def delete_then_raise(target_ref: OAuthRef) -> None:
+        oauth._delete_from_file(target_ref.key)
+        raise OSError(delete_detail)
+
+    def fail_restore(_ref: OAuthRef, _token: OAuthToken | None) -> None:
+        raise OSError(restore_detail)
+
+    monkeypatch.setattr(oauth, "delete_tokens", delete_then_raise)
+    monkeypatch.setattr(oauth, "_restore_token_snapshot", fail_restore)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="configuration was removed") as caught:
+        await oauth.persist_logout(
+            config,
+            ref,
+            lambda cfg: cfg.providers.__delitem__(provider_key),
+        )
+
+    assert delete_detail not in str(caught.value)
+    assert restore_detail not in str(caught.value)
+    assert str(tmp_path) not in str(caught.value)
+    assert provider_key not in load_config(get_config_file()).providers
+    assert oauth._load_from_file(ref.key) is None
+    assert provider_key not in config.providers
+
+
+@pytest.mark.asyncio
+async def test_persist_logout_without_prior_credential_does_not_retry_deletion(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:missing-logout-token"
+    ref = OAuthRef(storage="file", key="oauth/missing-logout-token")
+    config = Config(
+        is_from_default_location=True,
+        providers={provider_key: _provider("missing", oauth_ref=ref)},
+    )
+    save_config(config)
+    delete_calls = 0
+
+    def fail_delete(_ref: OAuthRef) -> None:
+        nonlocal delete_calls
+        delete_calls += 1
+        raise OSError("delete failed")
+
+    monkeypatch.setattr(oauth, "delete_tokens", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="logout was rolled back"):
+        await oauth.persist_logout(
+            config,
+            ref,
+            lambda cfg: cfg.providers.__delitem__(provider_key),
+        )
+
+    assert delete_calls == 1
+    assert provider_key in load_config(get_config_file()).providers
+    assert oauth._load_from_file(ref.key) is None
+
+
 def test_nested_oauth_ref_has_distinct_credential_and_lock_paths(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
     monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
 
-    flat_key = "oauth/xai"
-    nested_key = "oauth/snowflake-cortex/xai"
+    canonical_key = "oauth/lowercase-provider"
+    formerly_colliding_flat_key = "oauth/v2-YS9i"
+    nested_key = "oauth/a/b"
+    case_variant_nested_key = "oauth/a/G"
+    unsafe_flat_key = "oauth/account name"
+    non_prefixed_key = "lowercase-provider"
+    uppercase_key = "oauth/LOWERCASE-PROVIDER"
+    empty_key = ""
+    credentials_dir = tmp_path / "credentials"
 
-    assert oauth._credentials_path(flat_key).name == "xai.json"
-    assert oauth._credentials_lock_path(flat_key).name == "xai.lock"
-    assert oauth._credentials_path(nested_key) != oauth._credentials_path(flat_key)
-    assert oauth._credentials_lock_path(nested_key) != oauth._credentials_lock_path(flat_key)
+    assert oauth._credentials_path(canonical_key) == credentials_dir / "lowercase-provider.json"
+    assert (
+        oauth._credentials_lock_path(canonical_key) == credentials_dir / "lowercase-provider.lock"
+    )
+    assert oauth._credentials_path(nested_key) != oauth._credentials_path(
+        formerly_colliding_flat_key
+    )
+    assert oauth._credentials_lock_path(nested_key) != oauth._credentials_lock_path(
+        formerly_colliding_flat_key
+    )
+    assert oauth._credentials_path(nested_key).parent == credentials_dir / "v2"
+    assert oauth._credentials_lock_path(nested_key).parent == credentials_dir / "v2"
+    assert oauth._credentials_path(nested_key).stem == oauth._credentials_lock_path(nested_key).stem
+    assert (
+        str(oauth._credentials_path(nested_key)).casefold()
+        != str(oauth._credentials_path(case_variant_nested_key)).casefold()
+    )
+    assert (
+        str(oauth._credentials_lock_path(nested_key)).casefold()
+        != str(oauth._credentials_lock_path(case_variant_nested_key)).casefold()
+    )
+    assert oauth._credentials_path(unsafe_flat_key).parent == credentials_dir / "v2"
+    assert oauth._credentials_lock_path(unsafe_flat_key).parent == credentials_dir / "v2"
+    for aliased_key in (non_prefixed_key, uppercase_key, formerly_colliding_flat_key):
+        assert oauth._credentials_path(aliased_key).parent == credentials_dir / "v2"
+        assert oauth._credentials_lock_path(aliased_key).parent == credentials_dir / "v2"
+        assert oauth._credentials_path(aliased_key) != oauth._credentials_path(canonical_key)
+        assert oauth._credentials_lock_path(aliased_key) != oauth._credentials_lock_path(
+            canonical_key
+        )
+    for windows_unsafe_key in ("oauth/CON", "oauth/con.txt", "oauth/account."):
+        assert oauth._credentials_path(windows_unsafe_key).parent == credentials_dir / "v2"
+        assert oauth._credentials_lock_path(windows_unsafe_key).parent == credentials_dir / "v2"
+    assert oauth._credentials_path(empty_key) == credentials_dir / "v2" / "~.json"
+    assert oauth._credentials_lock_path(empty_key) == credentials_dir / "v2" / "~.lock"
+
+
+def test_keyring_missing_credential_delete_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    delete_called = False
+
+    def unexpected_delete(_service: str, _key: str) -> None:
+        nonlocal delete_called
+        delete_called = True
+
+    monkeypatch.setattr(oauth.keyring, "get_password", lambda _service, _key: None)
+    monkeypatch.setattr(oauth.keyring, "delete_password", unexpected_delete)
+
+    oauth._delete_from_keyring("oauth/missing")
+
+    assert not delete_called
+
+
+def test_keyring_delete_race_to_absent_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    reads = iter(["credential-present", None])
+
+    monkeypatch.setattr(oauth.keyring, "get_password", lambda _service, _key: next(reads))
+
+    def raced_delete(_service: str, _key: str) -> None:
+        raise keyring.errors.PasswordDeleteError("generic delete failure")
+
+    monkeypatch.setattr(oauth.keyring, "delete_password", raced_delete)
+
+    oauth._delete_from_keyring("oauth/raced")
+
+    with pytest.raises(StopIteration):
+        next(reads)
+
+
+def test_generic_keyring_delete_error_with_confirmed_absence_is_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credential: str | None = "credential-present"
+    reads = 0
+
+    def read_keyring(_service: str, _key: str) -> str | None:
+        nonlocal reads
+        reads += 1
+        return credential
+
+    def delete_then_raise(_service: str, _key: str) -> None:
+        nonlocal credential
+        credential = None
+        raise keyring.errors.KeyringError("ambiguous backend failure")
+
+    monkeypatch.setattr(oauth.keyring, "get_password", read_keyring)
+    monkeypatch.setattr(oauth.keyring, "delete_password", delete_then_raise)
+
+    oauth._delete_from_keyring("oauth/generic-race")
+
+    assert reads == 2
+    assert credential is None
+
+
+def test_generic_keyring_delete_error_with_confirmed_presence_is_typed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    reads = 0
+    secret_detail = f"ambiguous backend failure at {tmp_path}"
+
+    def read_keyring(_service: str, _key: str) -> str:
+        nonlocal reads
+        reads += 1
+        return "credential-still-present"
+
+    def fail_delete(_service: str, _key: str) -> None:
+        raise keyring.errors.KeyringError(secret_detail)
+
+    monkeypatch.setattr(oauth.keyring, "get_password", read_keyring)
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="system keyring") as caught:
+        oauth._delete_from_keyring("oauth/generic-present")
+
+    assert reads == 2
+    assert secret_detail not in str(caught.value)
+    assert str(tmp_path) not in str(caught.value)
+
+
+def test_keyring_delete_verification_failure_is_distinct_and_safe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    reads = 0
+    delete_detail = f"delete failed at {tmp_path}"
+    read_detail = f"verification failed at {tmp_path}"
+
+    def read_keyring(_service: str, _key: str) -> str:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return "credential-present"
+        raise keyring.errors.KeyringError(read_detail)
+
+    def fail_delete(_service: str, _key: str) -> None:
+        raise keyring.errors.KeyringError(delete_detail)
+
+    monkeypatch.setattr(oauth.keyring, "get_password", read_keyring)
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="verify") as caught:
+        oauth._delete_from_keyring("oauth/unknown-delete")
+
+    assert reads == 2
+    assert delete_detail not in str(caught.value)
+    assert read_detail not in str(caught.value)
+    assert str(tmp_path) not in str(caught.value)
+
+
+def test_keyring_password_delete_error_with_remaining_credential_is_typed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    secret_detail = f"backend database at {tmp_path} is unavailable"
+    monkeypatch.setattr(
+        oauth.keyring,
+        "get_password",
+        lambda _service, _key: "credential-still-present",
+    )
+
+    def fail_delete(_service: str, _key: str) -> None:
+        raise keyring.errors.PasswordDeleteError(secret_detail)
+
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        oauth._delete_from_keyring("oauth/provider")
+
+    assert secret_detail not in str(caught.value)
+    assert str(tmp_path) not in str(caught.value)
+    assert "system keyring" in str(caught.value)
+
+
+def test_keyring_backend_delete_failure_is_safe_and_typed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    secret_detail = f"backend database at {tmp_path} is unavailable"
+    monkeypatch.setattr(
+        oauth.keyring,
+        "get_password",
+        lambda _service, _key: "credential-still-present",
+    )
+
+    def fail_delete(_service: str, _key: str) -> None:
+        raise keyring.errors.KeyringError(secret_detail)
+
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        oauth._delete_from_keyring("oauth/provider")
+
+    assert secret_detail not in str(caught.value)
+    assert str(tmp_path) not in str(caught.value)
+    assert "system keyring" in str(caught.value)
+
+
+def test_keyring_backend_read_failure_is_safe_and_typed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    secret_detail = f"backend database at {tmp_path} is unavailable"
+    ref = OAuthRef(storage="keyring", key="oauth/provider")
+
+    def fail_read(_service: str, _key: str) -> str | None:
+        raise keyring.errors.KeyringError(secret_detail)
+
+    monkeypatch.setattr(oauth.keyring, "get_password", fail_read)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        oauth.load_tokens(ref)
+
+    assert secret_detail not in str(caught.value)
+    assert str(tmp_path) not in str(caught.value)
+    assert "system keyring" in str(caught.value)
+    assert not oauth._credentials_path(ref.key).exists()
+
+
+def test_malformed_keyring_token_is_safe_and_typed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/malformed-provider")
+    sensitive_payload = json.dumps(
+        {
+            "access_token": "secret-access-token",
+            "refresh_token": "secret-refresh-token",
+            "expires_at": "not-a-number",
+        }
+    )
+    monkeypatch.setattr(
+        oauth.keyring,
+        "get_password",
+        lambda _service, _key: sensitive_payload,
+    )
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        oauth.load_tokens(ref)
+
+    assert "secret-access-token" not in str(caught.value)
+    assert "secret-refresh-token" not in str(caught.value)
+    assert "system keyring" in str(caught.value)
+    assert not oauth._credentials_path(ref.key).exists()
+
+
+def _keyring_config(ref: OAuthRef) -> Config:
+    return Config(
+        is_from_default_location=True,
+        providers={"managed:keyring-provider": _provider("keyring", oauth_ref=ref)},
+    )
+
+
+def _keyring_payload(token: OAuthToken) -> str:
+    return json.dumps(token.to_dict())
+
+
+def test_manager_migrates_keyring_credential_and_preserves_authoritative_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/keyring-provider")
+    token = _token("access", "refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+    authoritative = load_config(get_config_file())
+    authoritative.providers["managed:concurrent"] = _provider("concurrent")
+    save_config(authoritative)
+    deleted: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        oauth.keyring,
+        "get_password",
+        lambda service, key: _keyring_payload(token),
+    )
+    monkeypatch.setattr(
+        oauth.keyring,
+        "delete_password",
+        lambda service, key: deleted.append((service, key)),
+    )
+
+    oauth.OAuthManager(caller)
+
+    committed = load_config(get_config_file())
+    assert committed.providers["managed:keyring-provider"].oauth == OAuthRef(
+        storage="file", key=ref.key
+    )
+    assert "managed:concurrent" in committed.providers
+    assert "managed:concurrent" in caller.providers
+    assert (
+        caller.providers["managed:keyring-provider"].oauth
+        == committed.providers["managed:keyring-provider"].oauth
+    )
+    assert oauth._load_from_file(ref.key) == token
+    assert deleted == [(oauth.KEYRING_SERVICE, ref.key)]
+
+
+def test_manager_migration_prefers_authoritative_keyring_over_stale_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/divergent-keyring-provider")
+    stale_file_token = _token("stale-file-access", "stale-file-refresh")
+    keyring_token = _token("keyring-access", "keyring-refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+    oauth._save_to_file(ref.key, stale_file_token)
+    credential: str | None = _keyring_payload(keyring_token)
+
+    monkeypatch.setattr(oauth.keyring, "get_password", lambda _service, _key: credential)
+
+    def delete_keyring(_service: str, _key: str) -> None:
+        nonlocal credential
+        assert oauth._load_from_file(ref.key) == keyring_token
+        credential = None
+
+    monkeypatch.setattr(oauth.keyring, "delete_password", delete_keyring)
+
+    oauth.OAuthManager(caller)
+
+    assert oauth._load_from_file(ref.key) == keyring_token
+    assert credential is None
+    committed_ref = load_config(get_config_file()).providers["managed:keyring-provider"].oauth
+    assert committed_ref == OAuthRef(storage="file", key=ref.key)
+    assert caller.providers["managed:keyring-provider"].oauth == committed_ref
+
+
+def test_manager_keyring_cleanup_failure_restores_previous_file_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/keyring-cleanup-rollback")
+    stale_file_token = _token("stale-file-access", "stale-file-refresh")
+    keyring_token = _token("keyring-access", "keyring-refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+    stale_snapshot = json.dumps(
+        stale_file_token.to_dict(),
+        indent=2,
+        sort_keys=True,
+    ).encode(encoding="utf-8")
+    oauth._credentials_path(ref.key).parent.mkdir(parents=True, exist_ok=True)
+    oauth._credentials_path(ref.key).write_bytes(stale_snapshot)
+    keyring_payload = _keyring_payload(keyring_token)
+
+    monkeypatch.setattr(
+        oauth.keyring,
+        "get_password",
+        lambda _service, _key: keyring_payload,
+    )
+
+    def fail_delete(_service: str, _key: str) -> None:
+        assert oauth._load_from_file(ref.key) == keyring_token
+        raise keyring.errors.KeyringError(f"sensitive backend at {tmp_path}")
+
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="rolled back") as caught:
+        oauth.OAuthManager(caller)
+
+    assert str(tmp_path) not in str(caught.value)
+    assert oauth._load_from_file(ref.key) == stale_file_token
+    assert oauth._credentials_path(ref.key).read_bytes() == stale_snapshot
+    assert oauth._load_from_keyring(ref.key) == keyring_token
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+
+
+def test_manager_keyring_cleanup_unknown_retains_authoritative_file_copy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/keyring-cleanup-unknown")
+    stale_file_token = _token("stale-file-access", "stale-file-refresh")
+    keyring_token = _token("keyring-access", "keyring-refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+    oauth._save_to_file(ref.key, stale_file_token)
+    reads = 0
+    keyring_payload = _keyring_payload(keyring_token)
+
+    def read_keyring(_service: str, _key: str) -> str:
+        nonlocal reads
+        reads += 1
+        if reads <= 2:
+            return keyring_payload
+        raise keyring.errors.KeyringError(f"sensitive verification at {tmp_path}")
+
+    def fail_delete(_service: str, _key: str) -> None:
+        assert oauth._load_from_file(ref.key) == keyring_token
+        raise keyring.errors.KeyringError(f"sensitive delete at {tmp_path}")
+
+    monkeypatch.setattr(oauth.keyring, "get_password", read_keyring)
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="could not be verified") as caught:
+        oauth.OAuthManager(caller)
+
+    assert str(tmp_path) not in str(caught.value)
+    assert oauth._load_from_file(ref.key) == keyring_token
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+
+
+def test_manager_migrates_authoritative_keyring_ref_missing_from_stale_caller(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/authoritative-keyring-provider")
+    token = _token("access", "refresh")
+    save_config(Config(is_from_default_location=True))
+    caller = load_config(get_config_file())
+    authoritative = load_config(get_config_file())
+    authoritative.providers["managed:keyring-provider"] = _provider("keyring", oauth_ref=ref)
+    save_config(authoritative)
+
+    monkeypatch.setattr(
+        oauth.keyring,
+        "get_password",
+        lambda _service, _key: _keyring_payload(token),
+    )
+    monkeypatch.setattr(oauth.keyring, "delete_password", lambda _service, _key: None)
+
+    oauth.OAuthManager(caller)
+
+    committed_ref = load_config(get_config_file()).providers["managed:keyring-provider"].oauth
+    assert committed_ref == OAuthRef(storage="file", key=ref.key)
+    assert caller.providers["managed:keyring-provider"].oauth == committed_ref
+    assert oauth._load_from_file(ref.key) == token
+
+
+def test_manager_keyring_migration_fails_closed_on_credential_lock_contention(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/locked-migration")
+    token = _token("access", "refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+    keyring_read = False
+
+    class ContendedLock:
+        def __init__(self, key: str) -> None:
+            assert key == ref.key
+
+        def acquire_with_retry_sync(self) -> bool:
+            return False
+
+        def release(self) -> None:
+            return None
+
+    def read_keyring(_service: str, _key: str) -> str:
+        nonlocal keyring_read
+        keyring_read = True
+        return _keyring_payload(token)
+
+    monkeypatch.setattr(oauth, "_CrossProcessLock", ContendedLock)
+    monkeypatch.setattr(oauth.keyring, "get_password", read_keyring)
+
+    with pytest.raises(oauth.OAuthPersistenceError, match="credential lock"):
+        oauth.OAuthManager(caller)
+
+    assert not keyring_read
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert not oauth._credentials_path(ref.key).exists()
+
+
+def test_manager_keeps_keyring_ref_when_credential_is_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/missing-provider")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+    monkeypatch.setattr(oauth.keyring, "get_password", lambda _service, _key: None)
+
+    oauth.OAuthManager(caller)
+
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert not oauth._credentials_path(ref.key).exists()
+    assert oauth._load_from_keyring(ref.key) is None
+
+
+def test_manager_keyring_read_failure_does_not_rewrite_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/read-failure")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+
+    def fail_read(_service: str, _key: str) -> str | None:
+        raise keyring.errors.KeyringError(f"sensitive backend {tmp_path}")
+
+    monkeypatch.setattr(oauth.keyring, "get_password", fail_read)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        oauth.OAuthManager(caller)
+
+    assert str(tmp_path) not in str(caught.value)
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert not oauth._credentials_path(ref.key).exists()
+
+
+def test_manager_keyring_delete_failure_rolls_back_file_and_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/delete-failure")
+    token = _token("access", "refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+
+    monkeypatch.setattr(
+        oauth.keyring, "get_password", lambda _service, _key: _keyring_payload(token)
+    )
+
+    def fail_delete(_service: str, _key: str) -> None:
+        raise keyring.errors.KeyringError(f"sensitive backend {tmp_path}")
+
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        oauth.OAuthManager(caller)
+
+    assert str(tmp_path) not in str(caught.value)
+    assert "rolled back" in str(caught.value)
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert not oauth._credentials_path(ref.key).exists()
+    assert oauth._load_from_keyring(ref.key) == token
+
+
+def test_manager_keyring_delete_and_file_rollback_failure_is_combined_and_safe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/rollback-failure")
+    token = _token("access", "refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+
+    monkeypatch.setattr(
+        oauth.keyring, "get_password", lambda _service, _key: _keyring_payload(token)
+    )
+
+    def fail_delete(_service: str, _key: str) -> None:
+        raise keyring.errors.KeyringError(f"sensitive backend {tmp_path}")
+
+    def fail_rollback(_key: str) -> None:
+        raise OSError(f"sensitive file {tmp_path}")
+
+    monkeypatch.setattr(oauth.keyring, "delete_password", fail_delete)
+    monkeypatch.setattr(oauth, "_delete_from_file", fail_rollback)
+
+    with pytest.raises(oauth.OAuthPersistenceError) as caught:
+        oauth.OAuthManager(caller)
+
+    assert str(tmp_path) not in str(caught.value)
+    assert "rollback also failed" in str(caught.value)
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert oauth._credentials_path(ref.key).exists()
+    assert oauth._load_from_keyring(ref.key) == token
+
+
+def test_manager_keyring_migration_respects_bounded_config_lock(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    ref = OAuthRef(storage="keyring", key="oauth/contended-migration")
+    token = _token("access", "refresh")
+    save_config(_keyring_config(ref))
+    caller = load_config(get_config_file())
+    lock_entered = threading.Event()
+    release_lock = threading.Event()
+
+    monkeypatch.setattr(
+        oauth.keyring, "get_password", lambda _service, _key: _keyring_payload(token)
+    )
+    monkeypatch.setattr(oauth.keyring, "delete_password", lambda _service, _key: None)
+    monkeypatch.setattr(oauth, "_PERSISTENCE_LOCK_TIMEOUT_SECONDS", 0.05)
+
+    def hold_config_lock() -> None:
+        with file_lock(get_config_file()):
+            lock_entered.set()
+            if not release_lock.wait(timeout=5):
+                raise TimeoutError("config-lock test barrier timed out")
+
+    holder = threading.Thread(target=hold_config_lock)
+    holder.start()
+    assert lock_entered.wait(timeout=5)
+    try:
+        with pytest.raises(oauth.OAuthPersistenceError, match="persistence is busy"):
+            oauth.OAuthManager(caller)
+    finally:
+        release_lock.set()
+        holder.join(timeout=5)
+
+    assert caller.providers["managed:keyring-provider"].oauth == ref
+    assert load_config(get_config_file()).providers["managed:keyring-provider"].oauth == ref
+    assert not oauth._credentials_path(ref.key).exists()

--- a/tests/auth/test_oauth_refresh.py
+++ b/tests/auth/test_oauth_refresh.py
@@ -12,8 +12,10 @@ from pythinker_code.auth.oauth import (
     _REJECTED_REFRESH_TOKENS,
     OAuthError,
     OAuthManager,
+    OAuthPersistenceError,
     OAuthToken,
     OAuthUnauthorized,
+    _credentials_path,
     _refresh_threshold,
     _save_to_file,
     refresh_token,
@@ -259,6 +261,64 @@ async def test_refresh_token_does_not_retry_on_400():
 
 
 @pytest.mark.asyncio
+async def test_ensure_fresh_scopes_to_active_runtime_provider():
+    xai_ref = OAuthRef(storage="file", key="oauth/xai")
+    copilot_ref = OAuthRef(storage="file", key="oauth/github-copilot")
+    xai_token = _make_token(access="stale-xai", refresh="xai-refresh", expires_in=0)
+    copilot_token = _make_token(access="stale-copilot", refresh="copilot-refresh", expires_in=0)
+    refreshed_copilot = _make_token(
+        access="fresh-copilot", refresh="copilot-refresh", expires_in=900
+    )
+    config = Config(
+        default_model="github-copilot/test-model",
+        providers={
+            "managed:xai": LLMProvider(
+                type="openai_legacy",
+                base_url="https://api.x.ai/v1",
+                api_key=SecretStr(""),
+                oauth=xai_ref,
+            ),
+            "managed:github-copilot": LLMProvider(
+                type="openai_legacy",
+                base_url="https://api.githubcopilot.com",
+                api_key=SecretStr(""),
+                oauth=copilot_ref,
+            ),
+        },
+        models={
+            "github-copilot/test-model": LLMModel(
+                provider="managed:github-copilot",
+                model="test-model",
+                max_context_size=100_000,
+            )
+        },
+        services=Services(),
+    )
+    tokens = {xai_ref.key: xai_token, copilot_ref.key: copilot_token}
+    runtime = MagicMock()
+    runtime.config = config
+    runtime.llm.model_config = config.models["github-copilot/test-model"]
+    runtime.llm.chat_provider.client.api_key = "stale-copilot"
+
+    with patch(
+        "pythinker_code.auth.oauth.load_tokens",
+        side_effect=lambda ref: tokens.get(ref.key),
+    ):
+        manager = OAuthManager(config)
+
+    refresh = AsyncMock(return_value=refreshed_copilot)
+    with (
+        patch("pythinker_code.auth.oauth.load_tokens", side_effect=lambda ref: tokens.get(ref.key)),
+        patch.object(manager, "_refresh_token_for_ref", refresh),
+        patch("pythinker_code.auth.oauth.save_tokens"),
+    ):
+        await manager.ensure_fresh(runtime)
+
+    refresh.assert_awaited_once_with(copilot_ref, "copilot-refresh")
+    assert runtime.llm.chat_provider.client.api_key == "fresh-copilot"
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_force_bypasses_threshold():
     """force=True should refresh even when token has plenty of time left."""
     token = _make_token(expires_in=800)  # 13+ minutes remaining
@@ -330,12 +390,12 @@ def test_save_to_file_is_atomic(tmp_path):
     with patch("pythinker_code.auth.oauth._credentials_dir", return_value=tmp_path):
         token = _make_token()
         _save_to_file(key, token)
-        path = tmp_path / f"{key}.json"
+        path = _credentials_path(key)
         assert path.exists()
         data = json.loads(path.read_text(encoding="utf-8"))
         assert data["access_token"] == "access-123"
         # No leftover .tmp files
-        tmp_files = list(tmp_path.glob("*.tmp"))
+        tmp_files = list(tmp_path.rglob("*.tmp"))
         assert tmp_files == []
 
 
@@ -345,7 +405,7 @@ def test_save_to_file_expires_in_roundtrip(tmp_path):
     with patch("pythinker_code.auth.oauth._credentials_dir", return_value=tmp_path):
         token = _make_token(expires_in=7200)
         _save_to_file(key, token)
-        path = tmp_path / f"{key}.json"
+        path = _credentials_path(key)
         data = json.loads(path.read_text(encoding="utf-8"))
         restored = OAuthToken.from_dict(data)
         assert restored.expires_in == 7200
@@ -365,6 +425,148 @@ def test_oauth_token_from_dict_defaults_expires_in():
     }
     token = OAuthToken.from_dict(payload)
     assert token.expires_in == 0.0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"refresh_token": "refresh-secret", "expires_in": 60},
+        {"access_token": None, "refresh_token": "refresh-secret", "expires_in": 60},
+        {"access_token": 123, "refresh_token": "refresh-secret", "expires_in": 60},
+        {"access_token": "", "refresh_token": "refresh-secret", "expires_in": 60},
+        {"access_token": " \t", "refresh_token": "refresh-secret", "expires_in": 60},
+    ],
+    ids=["missing", "none", "non-string", "empty", "blank"],
+)
+def test_oauth_token_from_response_rejects_invalid_access_token(
+    payload: dict[str, object],
+) -> None:
+    payload["provider_diagnostic"] = "raw-provider-payload-secret"
+
+    with pytest.raises(OAuthError) as raised:
+        OAuthToken.from_response(payload)
+
+    rendered = str(raised.value)
+    assert "raw-provider-payload-secret" not in rendered
+    assert "refresh-secret" not in rendered
+    assert str(payload) not in rendered
+
+
+@pytest.mark.parametrize(
+    "refresh_token",
+    [None, False, 123, ["raw-refresh-secret"], {"token": "raw-refresh-secret"}],
+    ids=["none", "bool", "integer", "list", "mapping"],
+)
+def test_oauth_token_from_response_rejects_supplied_non_string_refresh_token(
+    refresh_token: object,
+) -> None:
+    payload: dict[str, object] = {
+        "access_token": "access-secret",
+        "refresh_token": refresh_token,
+        "expires_in": 60,
+        "provider_diagnostic": "raw-provider-payload-secret",
+    }
+
+    with pytest.raises(OAuthError) as raised:
+        OAuthToken.from_response(payload)
+
+    rendered = str(raised.value)
+    assert "access-secret" not in rendered
+    assert "raw-refresh-secret" not in rendered
+    assert "raw-provider-payload-secret" not in rendered
+    assert str(payload) not in rendered
+
+
+@pytest.mark.parametrize(
+    "expires_in",
+    [
+        True,
+        -1,
+        -0.5,
+        "-1",
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        "NaN",
+        "Infinity",
+        "not-a-lifetime-secret",
+        [],
+        {},
+    ],
+    ids=[
+        "bool",
+        "negative-int",
+        "negative-float",
+        "negative-string",
+        "nan",
+        "positive-inf",
+        "negative-inf",
+        "nan-string",
+        "inf-string",
+        "malformed-string",
+        "list",
+        "mapping",
+    ],
+)
+def test_oauth_token_from_response_rejects_invalid_expires_in(expires_in: object) -> None:
+    payload: dict[str, object] = {
+        "access_token": "access-secret",
+        "refresh_token": "refresh-secret",
+        "expires_in": expires_in,
+        "provider_diagnostic": "raw-provider-payload-secret",
+    }
+
+    with pytest.raises(OAuthError) as raised:
+        OAuthToken.from_response(payload)
+
+    rendered = str(raised.value)
+    assert "access-secret" not in rendered
+    assert "refresh-secret" not in rendered
+    assert "raw-provider-payload-secret" not in rendered
+    assert "not-a-lifetime-secret" not in rendered
+    assert str(payload) not in rendered
+
+
+@pytest.mark.parametrize(
+    ("include_expires_in", "expires_in", "expected"),
+    [
+        (False, None, 0.0),
+        (True, None, 0.0),
+        (True, "", 0.0),
+        (True, 0, 0.0),
+        (True, 60, 60.0),
+        (True, 60.5, 60.5),
+        (True, "60", 60.0),
+        (True, "60.5", 60.5),
+    ],
+    ids=[
+        "missing",
+        "none",
+        "empty",
+        "zero",
+        "integer",
+        "float",
+        "integer-string",
+        "float-string",
+    ],
+)
+def test_oauth_token_from_response_accepts_valid_expires_in(
+    include_expires_in: bool,
+    expires_in: object,
+    expected: float,
+) -> None:
+    payload: dict[str, object] = {
+        "access_token": "access-token",
+        "refresh_token": "",
+    }
+    if include_expires_in:
+        payload["expires_in"] = expires_in
+
+    token = OAuthToken.from_response(payload)
+
+    assert token.access_token == "access-token"
+    assert token.refresh_token == ""
+    assert token.expires_in == expected
 
 
 # ── force refresh failure propagation ─────────────────────────
@@ -556,6 +758,36 @@ async def test_ensure_fresh_non_force_swallows_errors():
     ):
         # Should NOT raise — errors are swallowed in background mode
         await manager.ensure_fresh()
+
+
+@pytest.mark.asyncio
+async def test_refresh_lock_acquisition_failure_never_refreshes_or_writes_unlocked():
+    token = _make_token(expires_in=100)
+    manager = _make_manager(token)
+    refresh = AsyncMock(return_value=_make_token(access="unlocked-access"))
+    save = MagicMock()
+
+    class UnavailableLock:
+        def __init__(self, _key: str) -> None:
+            pass
+
+        async def acquire_with_retry(self) -> bool:
+            return False
+
+        def release(self) -> None:
+            pass
+
+    with (
+        patch("pythinker_code.auth.oauth.load_tokens", return_value=token),
+        patch("pythinker_code.auth.oauth._CrossProcessLock", UnavailableLock),
+        patch.object(manager, "_refresh_token_for_ref", refresh),
+        patch("pythinker_code.auth.oauth.save_tokens", save),
+        pytest.raises(OAuthPersistenceError, match="credential lock"),
+    ):
+        await manager.ensure_fresh(force=True)
+
+    refresh.assert_not_awaited()
+    save.assert_not_called()
 
 
 # ── _refresh_threshold helper ─────────────────────────────────

--- a/tests/auth/test_platforms.py
+++ b/tests/auth/test_platforms.py
@@ -358,8 +358,12 @@ async def test_refresh_managed_models_retries_after_oauth_401():
     assert changed is False
     assert list_models_mock.await_count == 2
     assert len(ensure_fresh_mock.await_args_list) == 2
-    assert ensure_fresh_mock.await_args_list[0].kwargs == {}
-    assert ensure_fresh_mock.await_args_list[1].kwargs == {"force": True}
+    oauth_ref = config.providers["managed:pythinker-code"].oauth
+    assert ensure_fresh_mock.await_args_list[0].kwargs == {"oauth_ref": oauth_ref}
+    assert ensure_fresh_mock.await_args_list[1].kwargs == {
+        "force": True,
+        "oauth_ref": oauth_ref,
+    }
 
 
 @pytest.mark.asyncio
@@ -405,8 +409,12 @@ async def test_refresh_managed_models_401_falls_back_to_static_api_key_when_refr
     assert list_models_mock.await_args_list[0].args[1] == "oauth-access-token"
     assert list_models_mock.await_args_list[1].args[1] == "static-api-key"
     assert len(ensure_fresh_mock.await_args_list) == 2
-    assert ensure_fresh_mock.await_args_list[0].kwargs == {}
-    assert ensure_fresh_mock.await_args_list[1].kwargs == {"force": True}
+    oauth_ref = config.providers["managed:pythinker-code"].oauth
+    assert ensure_fresh_mock.await_args_list[0].kwargs == {"oauth_ref": oauth_ref}
+    assert ensure_fresh_mock.await_args_list[1].kwargs == {
+        "force": True,
+        "oauth_ref": oauth_ref,
+    }
 
 
 def test_lm_studio_base_url_default(monkeypatch):
@@ -501,8 +509,12 @@ async def test_refresh_managed_models_401_tries_static_api_key_after_refreshed_o
     assert list_models_mock.await_args_list[1].args[1] == "fresh-oauth-token"
     assert list_models_mock.await_args_list[2].args[1] == "static-api-key"
     assert len(ensure_fresh_mock.await_args_list) == 2
-    assert ensure_fresh_mock.await_args_list[0].kwargs == {}
-    assert ensure_fresh_mock.await_args_list[1].kwargs == {"force": True}
+    oauth_ref = config.providers["managed:pythinker-code"].oauth
+    assert ensure_fresh_mock.await_args_list[0].kwargs == {"oauth_ref": oauth_ref}
+    assert ensure_fresh_mock.await_args_list[1].kwargs == {
+        "force": True,
+        "oauth_ref": oauth_ref,
+    }
 
 
 @pytest.mark.asyncio
@@ -735,7 +747,10 @@ def _make_opencode_go_config() -> Config:
 
 
 @pytest.mark.asyncio
-async def test_refresh_managed_models_refreshes_opencode_go_without_relogin():
+async def test_refresh_managed_models_refreshes_opencode_go_without_relogin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
     """The every-startup refresh must update OpenCode Go's two-provider catalog
     via its own discovery — surfacing new models (qwen3.7-max) and correcting
     Qwen's shape — without a manual re-login and without resetting user prefs."""
@@ -744,8 +759,11 @@ async def test_refresh_managed_models_refreshes_opencode_go_without_relogin():
         OPENCODE_GO_OPENAI_PROVIDER_KEY,
         OpenCodeGoModel,
     )
+    from pythinker_code.config import load_config, save_config
 
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
     config = _make_opencode_go_config()
+    save_config(config)
     discovered = (
         OpenCodeGoModel("kimi-k2.6", "Kimi K2.6", OPENCODE_GO_OPENAI_PROVIDER_KEY, 262_000),
         OpenCodeGoModel(
@@ -755,22 +773,12 @@ async def test_refresh_managed_models_refreshes_opencode_go_without_relogin():
             "qwen3.7-max", "Qwen3.7 Max", OPENCODE_GO_ANTHROPIC_PROVIDER_KEY, 1_000_000
         ),
     )
-    saved: list[Config] = []
-
     with (
         patch(
             "pythinker_code.auth.opencode_go._discover_opencode_go_models",
             new=AsyncMock(return_value=discovered),
         ),
         patch("pythinker_code.auth.platforms.list_models", new=AsyncMock()) as list_models_mock,
-        patch(
-            "pythinker_code.auth.platforms.load_config",
-            return_value=_make_opencode_go_config(),
-        ),
-        patch(
-            "pythinker_code.auth.platforms.save_config",
-            side_effect=lambda cfg, *a, **k: saved.append(cfg),
-        ),
     ):
         changed = await refresh_managed_models(config)
 
@@ -785,12 +793,14 @@ async def test_refresh_managed_models_refreshes_opencode_go_without_relogin():
     assert config.default_model == "opencode-go/kimi-k2.6"
     assert config.default_thinking is True
     # Persisted to disk for subsequent launches.
-    assert len(saved) == 1
-    assert "opencode-go/qwen3.7-max" in saved[0].models
+    assert "opencode-go/qwen3.7-max" in load_config().models
 
 
 @pytest.mark.asyncio
-async def test_refresh_managed_models_isolates_opencode_go_discovery_failure():
+async def test_refresh_managed_models_isolates_opencode_go_discovery_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
     """An OpenCode Go discovery failure must not abort other providers' refresh
     or mangle the saved OpenCode Go list."""
     from pythinker_code.auth.opencode_go import OPENCODE_GO_OPENAI_PROVIDER_KEY
@@ -807,7 +817,11 @@ async def test_refresh_managed_models_isolates_opencode_go_discovery_failure():
         )
         return cfg
 
+    from pythinker_code.config import load_config, save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
     config = _config_with_generic_provider()
+    save_config(config)
     generic_models = [
         ModelInfo(
             id="pythinker-for-coding",
@@ -818,8 +832,6 @@ async def test_refresh_managed_models_isolates_opencode_go_discovery_failure():
             display_name=None,
         )
     ]
-    saved: list[Config] = []
-
     with (
         patch(
             "pythinker_code.auth.opencode_go._discover_opencode_go_models",
@@ -829,21 +841,13 @@ async def test_refresh_managed_models_isolates_opencode_go_discovery_failure():
             "pythinker_code.auth.platforms.list_models",
             new=AsyncMock(return_value=generic_models),
         ),
-        patch(
-            "pythinker_code.auth.platforms.load_config",
-            side_effect=_config_with_generic_provider,
-        ),
-        patch(
-            "pythinker_code.auth.platforms.save_config",
-            side_effect=lambda cfg, *a, **k: saved.append(cfg),
-        ),
     ):
         changed = await refresh_managed_models(config)
 
     # The generic provider's refresh still succeeds and persists.
     assert changed is True
-    assert len(saved) == 1
-    assert saved[0].models["pythinker-code/pythinker-for-coding"].max_context_size == 200_000
+    saved = load_config()
+    assert saved.models["pythinker-code/pythinker-for-coding"].max_context_size == 200_000
     # OpenCode Go list is left exactly as-is (not wiped, not half-applied).
     assert "opencode-go/qwen3.7-max" not in config.models
     assert config.models["opencode-go/qwen3.5-plus"].provider == OPENCODE_GO_OPENAI_PROVIDER_KEY
@@ -890,7 +894,10 @@ def _make_minimax_config() -> Config:
 
 
 @pytest.mark.asyncio
-async def test_refresh_managed_models_refreshes_minimax_token_plan_without_relogin():
+async def test_refresh_managed_models_refreshes_minimax_token_plan_without_relogin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
     """MiniMax startup refresh must use the authenticated live catalog.
 
     Token Plan availability is key-specific, so stale aliases from an older
@@ -901,25 +908,21 @@ async def test_refresh_managed_models_refreshes_minimax_token_plan_without_relog
         MINIMAX_ANTHROPIC_PROVIDER_KEY,
         MiniMaxModel,
     )
+    from pythinker_code.config import load_config, save_config
 
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
     config = _make_minimax_config()
+    save_config(config)
     discovered = (
         MiniMaxModel("MiniMax-M2.7", "m2.7", "MiniMax M2.7", max_context_size=205_000),
         MiniMaxModel("MiniMax-M3", "m3", "MiniMax M3", max_context_size=512_000),
     )
-    saved: list[Config] = []
-
     with (
         patch(
             "pythinker_code.auth.minimax.refresh_minimax_models",
             new=AsyncMock(return_value=discovered),
         ),
         patch("pythinker_code.auth.platforms.list_models", new=AsyncMock()) as list_models_mock,
-        patch("pythinker_code.auth.platforms.load_config", side_effect=_make_minimax_config),
-        patch(
-            "pythinker_code.auth.platforms.save_config",
-            side_effect=lambda cfg, *a, **k: saved.append(cfg),
-        ),
     ):
         changed = await refresh_managed_models(config)
 
@@ -930,18 +933,23 @@ async def test_refresh_managed_models_refreshes_minimax_token_plan_without_relog
     assert config.models["minimax/m3"].provider == MINIMAX_ANTHROPIC_PROVIDER_KEY
     assert config.default_model == "minimax/m3"
     assert config.default_thinking is True
-    assert len(saved) == 1
-    assert "minimax/m3" in saved[0].models
-    assert "minimax/m2.7-highspeed" not in saved[0].models
+    saved = load_config()
+    assert "minimax/m3" in saved.models
+    assert "minimax/m2.7-highspeed" not in saved.models
 
 
 @pytest.mark.asyncio
-async def test_refresh_managed_models_applies_empty_minimax_catalog():
+async def test_refresh_managed_models_applies_empty_minimax_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
     """An authenticated empty MiniMax catalog is authoritative and prunes stale models."""
     from pythinker_code.auth.minimax import MINIMAX_ANTHROPIC_PROVIDER_KEY
+    from pythinker_code.config import load_config, save_config
 
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
     config = _make_minimax_config()
-    saved: list[Config] = []
+    save_config(config)
 
     with (
         patch(
@@ -949,11 +957,6 @@ async def test_refresh_managed_models_applies_empty_minimax_catalog():
             new=AsyncMock(return_value=()),
         ) as refresh_mock,
         patch("pythinker_code.auth.platforms.list_models", new=AsyncMock()) as list_models_mock,
-        patch("pythinker_code.auth.platforms.load_config", side_effect=_make_minimax_config),
-        patch(
-            "pythinker_code.auth.platforms.save_config",
-            side_effect=lambda cfg, *a, **k: saved.append(cfg),
-        ),
     ):
         changed = await refresh_managed_models(config)
 
@@ -964,14 +967,17 @@ async def test_refresh_managed_models_applies_empty_minimax_catalog():
         model.provider == MINIMAX_ANTHROPIC_PROVIDER_KEY for model in config.models.values()
     )
     assert config.default_model == ""
-    assert len(saved) == 1
+    saved = load_config()
     assert not any(
-        model.provider == MINIMAX_ANTHROPIC_PROVIDER_KEY for model in saved[0].models.values()
+        model.provider == MINIMAX_ANTHROPIC_PROVIDER_KEY for model in saved.models.values()
     )
 
 
 @pytest.mark.asyncio
-async def test_refresh_managed_models_isolates_minimax_discovery_failure():
+async def test_refresh_managed_models_isolates_minimax_discovery_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
     """MiniMax refresh failure must not abort other managed-provider refreshes."""
 
     def _config_with_generic_provider() -> Config:
@@ -988,7 +994,11 @@ async def test_refresh_managed_models_isolates_minimax_discovery_failure():
         )
         return cfg
 
+    from pythinker_code.config import load_config, save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
     config = _config_with_generic_provider()
+    save_config(config)
     generic_models = [
         ModelInfo(
             id="pythinker-for-coding",
@@ -999,8 +1009,6 @@ async def test_refresh_managed_models_isolates_minimax_discovery_failure():
             display_name=None,
         )
     ]
-    saved: list[Config] = []
-
     with (
         patch(
             "pythinker_code.auth.minimax.refresh_minimax_models",
@@ -1010,22 +1018,14 @@ async def test_refresh_managed_models_isolates_minimax_discovery_failure():
             "pythinker_code.auth.platforms.list_models",
             new=AsyncMock(return_value=generic_models),
         ),
-        patch(
-            "pythinker_code.auth.platforms.load_config",
-            side_effect=_config_with_generic_provider,
-        ),
-        patch(
-            "pythinker_code.auth.platforms.save_config",
-            side_effect=lambda cfg, *a, **k: saved.append(cfg),
-        ),
     ):
         changed = await refresh_managed_models(config)
 
     assert changed is True
-    assert len(saved) == 1
-    assert saved[0].models["pythinker-code/pythinker-for-coding"].max_context_size == 200_000
-    assert "minimax/m2.7-highspeed" in saved[0].models
-    assert saved[0].models["minimax/m2.7-highspeed"].provider == "managed:minimax-anthropic"
+    saved = load_config()
+    assert saved.models["pythinker-code/pythinker-for-coding"].max_context_size == 200_000
+    assert "minimax/m2.7-highspeed" in saved.models
+    assert saved.models["minimax/m2.7-highspeed"].provider == "managed:minimax-anthropic"
     assert "minimax/m2.7-highspeed" in config.models
 
 
@@ -1101,3 +1101,323 @@ async def test_refresh_zai_routes_apply_live_catalog_independently(
         if value.provider == ZAI_API_ROUTE.provider_key
     }
     assert reloaded_api == api_before
+
+
+@pytest.mark.asyncio
+async def test_refresh_managed_models_merges_stale_discovery_into_authoritative_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    from pythinker_code.auth import platforms
+    from pythinker_code.config import load_config, save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    stale = _make_config_with_model(api_key="static-api-key")
+    stale.is_from_default_location = True
+    stale.providers["managed:pythinker-code"].oauth = None
+    authoritative = stale.model_copy(deep=True)
+    authoritative.providers["managed:concurrent-login"] = LLMProvider(
+        type="openai_legacy",
+        base_url="https://concurrent.example/v1",
+        api_key=SecretStr("concurrent-key"),
+    )
+    save_config(authoritative)
+    discovered = [
+        ModelInfo(
+            id="pythinker-for-coding",
+            context_length=200_000,
+            supports_reasoning=False,
+            supports_image_in=False,
+            supports_video_in=False,
+        )
+    ]
+
+    monkeypatch.setattr(platforms, "list_models", AsyncMock(return_value=discovered))
+    # Model the background writer having read before the concurrent login committed.
+    monkeypatch.setattr(
+        platforms,
+        "load_config",
+        lambda: stale.model_copy(deep=True),
+        raising=False,
+    )
+
+    changed = await refresh_managed_models(stale)
+
+    committed = load_config()
+    assert changed is True
+    assert "managed:concurrent-login" in committed.providers
+    assert committed.models["pythinker-code/pythinker-for-coding"].max_context_size == 200_000
+    assert "managed:concurrent-login" in stale.providers
+    assert stale.models["pythinker-code/pythinker-for-coding"].max_context_size == 200_000
+
+
+@pytest.mark.asyncio
+async def test_refresh_managed_models_does_not_mutate_caller_during_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    from pythinker_code.auth import opencode_go, platforms
+    from pythinker_code.config import save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    config = _make_config_with_model(api_key="static-api-key")
+    config.is_from_default_location = True
+    config.providers["managed:pythinker-code"].oauth = None
+    before = config.model_copy(deep=True)
+    save_config(config)
+    discovered = [
+        ModelInfo(
+            id="pythinker-for-coding",
+            context_length=200_000,
+            supports_reasoning=False,
+            supports_image_in=False,
+            supports_video_in=False,
+        )
+    ]
+    observations: list[bool] = []
+
+    async def observe_later_discovery(candidate: Config) -> None:
+        observations.append(candidate is not config and config == before)
+        return None
+
+    monkeypatch.setattr(platforms, "list_models", AsyncMock(return_value=discovered))
+    monkeypatch.setattr(opencode_go, "refresh_opencode_go_models", observe_later_discovery)
+
+    changed = await refresh_managed_models(config)
+
+    assert changed is True
+    assert observations == [True]
+    assert config.models["pythinker-code/pythinker-for-coding"].max_context_size == 200_000
+
+
+@pytest.mark.asyncio
+async def test_refresh_managed_models_persists_collected_noop_to_authoritative_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    from pythinker_code.auth import platforms
+    from pythinker_code.config import load_config, save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    caller = _make_config_with_model(api_key="static-api-key")
+    caller.is_from_default_location = True
+    caller.providers["managed:pythinker-code"].oauth = None
+    authoritative = caller.model_copy(deep=True)
+    authoritative.models["pythinker-code/pythinker-for-coding"].max_context_size = 50_000
+    save_config(authoritative)
+    discovered = [
+        ModelInfo(
+            id="pythinker-for-coding",
+            context_length=100_000,
+            supports_reasoning=False,
+            supports_image_in=False,
+            supports_video_in=False,
+        )
+    ]
+    monkeypatch.setattr(platforms, "list_models", AsyncMock(return_value=discovered))
+
+    changed = await refresh_managed_models(caller)
+
+    committed = load_config()
+    assert changed is False
+    assert committed.models["pythinker-code/pythinker-for-coding"].max_context_size == 100_000
+    assert caller.models["pythinker-code/pythinker-for-coding"].max_context_size == 100_000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("concurrent_change", ["logout", "replacement"])
+async def test_refresh_managed_models_drops_results_after_provider_identity_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+    concurrent_change: str,
+) -> None:
+    from pythinker_code.auth import platforms
+    from pythinker_code.auth.oauth import persist_config_change
+    from pythinker_code.config import load_config, save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    provider_key = "managed:pythinker-code"
+    old_alias = "pythinker-code/old-model"
+    new_alias = "pythinker-code/new-account-model"
+    config = Config(
+        is_from_default_location=True,
+        default_model=old_alias,
+        providers={
+            provider_key: LLMProvider(
+                type="pythinker",
+                base_url="https://old.example/v1",
+                api_key=SecretStr("old-key"),
+            )
+        },
+        models={
+            old_alias: LLMModel(
+                provider=provider_key,
+                model="old-model",
+                max_context_size=100_000,
+            )
+        },
+    )
+    save_config(config)
+    concurrent_caller = config.model_copy(deep=True)
+
+    async def discover_then_change_provider(*_args: Any, **_kwargs: Any) -> list[ModelInfo]:
+        def change_provider(authoritative: Config) -> None:
+            authoritative.providers.pop(provider_key, None)
+            authoritative.models = {
+                alias: model
+                for alias, model in authoritative.models.items()
+                if model.provider != provider_key
+            }
+            authoritative.default_model = ""
+            if concurrent_change == "replacement":
+                authoritative.providers[provider_key] = LLMProvider(
+                    type="pythinker",
+                    base_url="https://new.example/v1",
+                    api_key=SecretStr("new-key"),
+                )
+                authoritative.models[new_alias] = LLMModel(
+                    provider=provider_key,
+                    model="new-account-model",
+                    max_context_size=300_000,
+                )
+                authoritative.default_model = new_alias
+
+        await persist_config_change(concurrent_caller, change_provider)
+        return [
+            ModelInfo(
+                id="old-model",
+                context_length=200_000,
+                supports_reasoning=False,
+                supports_image_in=False,
+                supports_video_in=False,
+            )
+        ]
+
+    monkeypatch.setattr(platforms, "list_models", discover_then_change_provider)
+
+    changed = await refresh_managed_models(config)
+
+    committed = load_config()
+    assert changed is True
+    if concurrent_change == "logout":
+        assert provider_key not in committed.providers
+        assert not any(model.provider == provider_key for model in committed.models.values())
+    else:
+        assert committed.providers[provider_key].base_url == "https://new.example/v1"
+        assert new_alias in committed.models
+        assert old_alias not in committed.models
+    assert config.providers == committed.providers
+    assert config.models == committed.models
+
+
+@pytest.mark.asyncio
+async def test_refresh_managed_models_ignores_empty_opencode_go_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    from pythinker_code.auth import opencode_go, platforms
+    from pythinker_code.config import load_config, save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    config = _make_opencode_go_config()
+    before = config.model_copy(deep=True)
+    save_config(config)
+    monkeypatch.setattr(opencode_go, "refresh_opencode_go_models", AsyncMock(return_value=()))
+    monkeypatch.setattr(platforms, "list_models", AsyncMock())
+
+    changed = await refresh_managed_models(config)
+
+    assert changed is False
+    assert config.models == before.models
+    assert load_config().models == before.models
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("concurrent_change", ["logout", "replacement"])
+async def test_refresh_managed_models_drops_opencode_results_after_provider_group_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+    concurrent_change: str,
+) -> None:
+    from pythinker_code.auth import opencode_go, platforms
+    from pythinker_code.auth.oauth import persist_config_change
+    from pythinker_code.auth.opencode_go import (
+        OPENCODE_GO_ANTHROPIC_BASE_URL,
+        OPENCODE_GO_ANTHROPIC_PROVIDER_KEY,
+        OPENCODE_GO_BASE_URL,
+        OPENCODE_GO_OPENAI_PROVIDER_KEY,
+        OpenCodeGoModel,
+    )
+    from pythinker_code.config import load_config, save_config
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    config = _make_opencode_go_config()
+    save_config(config)
+    concurrent_caller = config.model_copy(deep=True)
+    replacement_alias = "opencode-go/replacement-model"
+
+    async def discover_then_change_provider_group(
+        _working_config: Config,
+    ) -> tuple[OpenCodeGoModel, ...]:
+        def change_provider_group(authoritative: Config) -> None:
+            for provider_key in (
+                OPENCODE_GO_OPENAI_PROVIDER_KEY,
+                OPENCODE_GO_ANTHROPIC_PROVIDER_KEY,
+            ):
+                authoritative.providers.pop(provider_key, None)
+            authoritative.models = {
+                alias: model
+                for alias, model in authoritative.models.items()
+                if model.provider
+                not in {OPENCODE_GO_OPENAI_PROVIDER_KEY, OPENCODE_GO_ANTHROPIC_PROVIDER_KEY}
+            }
+            authoritative.default_model = ""
+            if concurrent_change == "replacement":
+                authoritative.providers[OPENCODE_GO_OPENAI_PROVIDER_KEY] = LLMProvider(
+                    type="openai_legacy",
+                    base_url=OPENCODE_GO_BASE_URL,
+                    api_key=SecretStr("replacement-key"),
+                )
+                authoritative.providers[OPENCODE_GO_ANTHROPIC_PROVIDER_KEY] = LLMProvider(
+                    type="anthropic",
+                    base_url=OPENCODE_GO_ANTHROPIC_BASE_URL,
+                    api_key=SecretStr("replacement-key"),
+                )
+                authoritative.models[replacement_alias] = LLMModel(
+                    provider=OPENCODE_GO_OPENAI_PROVIDER_KEY,
+                    model="replacement-model",
+                    max_context_size=400_000,
+                )
+                authoritative.default_model = replacement_alias
+
+        await persist_config_change(concurrent_caller, change_provider_group)
+        return (
+            OpenCodeGoModel(
+                "stale-discovery-model",
+                "Stale Discovery Model",
+                OPENCODE_GO_OPENAI_PROVIDER_KEY,
+                200_000,
+            ),
+        )
+
+    monkeypatch.setattr(
+        opencode_go, "refresh_opencode_go_models", discover_then_change_provider_group
+    )
+    monkeypatch.setattr(platforms, "list_models", AsyncMock())
+
+    changed = await refresh_managed_models(config)
+
+    committed = load_config()
+    assert changed is True
+    assert "opencode-go/stale-discovery-model" not in committed.models
+    if concurrent_change == "logout":
+        assert OPENCODE_GO_OPENAI_PROVIDER_KEY not in committed.providers
+        assert OPENCODE_GO_ANTHROPIC_PROVIDER_KEY not in committed.providers
+    else:
+        assert replacement_alias in committed.models
+        assert (
+            committed.providers[OPENCODE_GO_OPENAI_PROVIDER_KEY].api_key.get_secret_value()
+            == "replacement-key"
+        )
+    assert config.providers == committed.providers
+    assert config.models == committed.models

--- a/tests/auth/test_snowflake_auth.py
+++ b/tests/auth/test_snowflake_auth.py
@@ -19,7 +19,15 @@ from pythinker_code.auth.oauth import (
     save_tokens,
 )
 from pythinker_code.auth.oauth_flows import LoopbackAuthorization
-from pythinker_code.config import Config, LLMModel, LLMProvider, OAuthRef
+from pythinker_code.config import (
+    Config,
+    LLMModel,
+    LLMProvider,
+    OAuthRef,
+    get_config_file,
+    load_config,
+    save_config,
+)
 
 
 def _mock_unavailable_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -180,6 +188,61 @@ async def test_refresh_uses_account_endpoint_basic_auth_and_default_expiry(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("include_expiry", [False, True], ids=("missing", "explicit-none"))
+async def test_refresh_defaults_missing_or_none_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+    include_expiry: bool,
+) -> None:
+    from pythinker_code.auth import snowflake
+
+    payload: dict[str, object] = {"access_token": "access", "refresh_token": "refresh"}
+    if include_expiry:
+        payload["expires_in"] = None
+    response = _FormResponse(200, payload)
+    monkeypatch.setattr(snowflake, "new_client_session", lambda: _FormSession(response, []))
+
+    token = await snowflake.refresh_snowflake_cortex_token("myorg-acct", "old-refresh")
+
+    assert token.expires_in == 600
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("expires_in", "expected"), [(0, 0.0), ("", 0.0)])
+async def test_refresh_preserves_explicit_falsy_expiry_for_shared_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    expires_in: object,
+    expected: float,
+) -> None:
+    from pythinker_code.auth import snowflake
+
+    response = _FormResponse(
+        200,
+        {"access_token": "access", "refresh_token": "refresh", "expires_in": expires_in},
+    )
+    monkeypatch.setattr(snowflake, "new_client_session", lambda: _FormSession(response, []))
+
+    token = await snowflake.refresh_snowflake_cortex_token("myorg-acct", "old-refresh")
+
+    assert token.expires_in == expected
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_explicit_false_expiry_via_shared_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pythinker_code.auth import snowflake
+
+    response = _FormResponse(
+        200,
+        {"access_token": "access", "refresh_token": "refresh", "expires_in": False},
+    )
+    monkeypatch.setattr(snowflake, "new_client_session", lambda: _FormSession(response, []))
+
+    with pytest.raises(OAuthError, match="invalid expiration lifetime"):
+        await snowflake.refresh_snowflake_cortex_token("myorg-acct", "old-refresh")
+
+
+@pytest.mark.asyncio
 async def test_refresh_maps_invalid_grant_to_unauthorized(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -295,6 +358,69 @@ async def test_login_snowflake_saves_account_scoped_token_provider_and_models(
 
 
 @pytest.mark.asyncio
+async def test_login_snowflake_account_switch_removes_old_account_credential(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from pythinker_code.auth import snowflake
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    old_ref = OAuthRef(storage="file", key="oauth/snowflake-cortex/old-account")
+    new_ref = OAuthRef(storage="file", key="oauth/snowflake-cortex/new-account")
+    save_tokens(
+        old_ref,
+        OAuthToken.from_response(
+            {
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "expires_in": 600,
+            }
+        ),
+    )
+    config = Config(
+        is_from_default_location=True,
+        providers={
+            snowflake.SNOWFLAKE_PROVIDER_KEY: LLMProvider(
+                type="openai_legacy",
+                base_url="https://old-account.snowflakecomputing.com/api/v2/cortex/v1",
+                api_key=SecretStr(""),
+                oauth=old_ref,
+            )
+        },
+    )
+    save_config(config)
+
+    async def fake_loopback(**_kwargs: Any) -> LoopbackAuthorization:
+        return LoopbackAuthorization("auth-code", "verifier", "http://127.0.0.1:49231/")
+
+    async def fake_exchange(
+        _account: str,
+        _code: str,
+        _code_verifier: str,
+        _redirect_uri: str,
+    ) -> dict[str, Any]:
+        return {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 600,
+        }
+
+    monkeypatch.setattr(snowflake, "run_loopback_pkce_flow", fake_loopback)
+    monkeypatch.setattr(snowflake, "_exchange_code_for_tokens", fake_exchange)
+    _mock_unavailable_catalog(monkeypatch)
+
+    events = [event async for event in snowflake.login_snowflake(config, "new-account")]
+
+    assert [event.type for event in events] == ["waiting", "success"]
+    assert load_tokens(old_ref) is None
+    stored_new = load_tokens(new_ref)
+    assert stored_new is not None
+    assert stored_new.access_token == "new-access"
+    assert config.providers[snowflake.SNOWFLAKE_PROVIDER_KEY].oauth == new_ref
+    assert load_config(get_config_file()) == config
+
+
+@pytest.mark.asyncio
 async def test_snowflake_persistence_errors_hide_internal_details(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -328,7 +454,7 @@ async def test_snowflake_persistence_errors_hide_internal_details(
     monkeypatch.setattr(snowflake, "_exchange_code_for_tokens", fake_exchange)
     monkeypatch.setattr(snowflake, "_discover_snowflake_models", fake_models)
     monkeypatch.setattr(snowflake, "persist_login", fail_persistence)
-    monkeypatch.setattr(snowflake, "persist_config_change", fail_persistence)
+    monkeypatch.setattr(snowflake, "persist_logout", fail_persistence)
 
     login_events = [event async for event in snowflake.login_snowflake(config, "myorg-acct")]
     logout_events = [event async for event in snowflake.logout_snowflake(config)]
@@ -369,6 +495,55 @@ async def test_login_snowflake_fails_when_refresh_token_is_missing(
     assert "refresh token" in events[-1].message
     assert "managed:snowflake-cortex" not in config.providers
     assert load_tokens(OAuthRef(storage="file", key="oauth/snowflake-cortex/myorg-acct")) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "access_token",
+    ["", {"token": "raw-provider-access-secret"}],
+    ids=["empty", "non-string"],
+)
+async def test_login_snowflake_rejects_invalid_access_token_safely(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    access_token: object,
+) -> None:
+    from pythinker_code.auth import snowflake
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    config = Config(is_from_default_location=True)
+
+    async def fake_loopback(**_kwargs: Any) -> LoopbackAuthorization:
+        return LoopbackAuthorization("auth-code", "verifier", "http://127.0.0.1:49231/")
+
+    async def fake_exchange(
+        _account: str,
+        _code: str,
+        _code_verifier: str,
+        _redirect_uri: str,
+    ) -> dict[str, Any]:
+        return {
+            "access_token": access_token,
+            "refresh_token": "raw-provider-refresh-secret",
+            "expires_in": 600,
+            "provider_diagnostic": "raw-provider-payload-secret",
+        }
+
+    monkeypatch.setattr(snowflake, "run_loopback_pkce_flow", fake_loopback)
+    monkeypatch.setattr(snowflake, "_exchange_code_for_tokens", fake_exchange)
+    _mock_unavailable_catalog(monkeypatch)
+
+    events = [event async for event in snowflake.login_snowflake(config, "myorg-acct")]
+
+    assert [event.type for event in events] == ["waiting", "error"]
+    rendered_events = "\n".join(event.json for event in events)
+    assert "raw-provider-access-secret" not in rendered_events
+    assert "raw-provider-refresh-secret" not in rendered_events
+    assert "raw-provider-payload-secret" not in rendered_events
+    oauth_ref = OAuthRef(storage="file", key="oauth/snowflake-cortex/myorg-acct")
+    assert load_tokens(oauth_ref) is None
+    assert "managed:snowflake-cortex" not in config.providers
+    assert config.models == {}
 
 
 @pytest.mark.asyncio
@@ -446,6 +621,63 @@ async def test_logout_snowflake_removes_account_token_provider_models_and_repair
     assert SNOWFLAKE_PROVIDER_KEY not in config.providers
     assert all(model.provider != SNOWFLAKE_PROVIDER_KEY for model in config.models.values())
     assert config.default_model == "fallback/model"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("caller_has_stale_provider", [True, False])
+async def test_logout_snowflake_deletes_authoritative_account_from_stale_caller(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caller_has_stale_provider: bool,
+) -> None:
+    from pythinker_code.auth.snowflake import SNOWFLAKE_PROVIDER_KEY, logout_snowflake
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    stale_ref = OAuthRef(storage="file", key="oauth/snowflake-cortex/stale-account")
+    authoritative_ref = OAuthRef(storage="file", key="oauth/snowflake-cortex/authoritative-account")
+    caller = Config(is_from_default_location=True)
+    if caller_has_stale_provider:
+        caller.providers[SNOWFLAKE_PROVIDER_KEY] = LLMProvider(
+            type="openai_legacy",
+            base_url="https://stale-account.snowflakecomputing.com/api/v2/cortex/v1",
+            api_key=SecretStr(""),
+            oauth=stale_ref,
+        )
+    authoritative = Config(
+        is_from_default_location=True,
+        providers={
+            SNOWFLAKE_PROVIDER_KEY: LLMProvider(
+                type="openai_legacy",
+                base_url=("https://authoritative-account.snowflakecomputing.com/api/v2/cortex/v1"),
+                api_key=SecretStr(""),
+                oauth=authoritative_ref,
+            )
+        },
+        models={
+            "snowflake-cortex/model": LLMModel(
+                provider=SNOWFLAKE_PROVIDER_KEY,
+                model="model",
+                max_context_size=128_000,
+            )
+        },
+    )
+    save_config(authoritative)
+    save_tokens(stale_ref, OAuthToken.from_response({"access_token": "stale"}))
+    save_tokens(
+        authoritative_ref,
+        OAuthToken.from_response({"access_token": "authoritative"}),
+    )
+
+    events = [event async for event in logout_snowflake(caller)]
+
+    committed = load_config()
+    assert [event.type for event in events] == ["success"]
+    assert SNOWFLAKE_PROVIDER_KEY not in committed.providers
+    assert not any(model.provider == SNOWFLAKE_PROVIDER_KEY for model in committed.models.values())
+    assert load_tokens(authoritative_ref) is None
+    assert load_tokens(stale_ref) is not None
+    assert SNOWFLAKE_PROVIDER_KEY not in caller.providers
+    assert not any(model.provider == SNOWFLAKE_PROVIDER_KEY for model in caller.models.values())
 
 
 @pytest.mark.asyncio

--- a/tests/auth/test_xai_auth.py
+++ b/tests/auth/test_xai_auth.py
@@ -254,6 +254,53 @@ async def test_login_xai_browser_rejects_missing_refresh_token(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "access_token",
+    ["", {"token": "raw-provider-access-secret"}],
+    ids=["empty", "non-string"],
+)
+async def test_login_xai_browser_rejects_invalid_access_token_safely(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    access_token: object,
+) -> None:
+    from pythinker_code.auth import xai
+
+    monkeypatch.setenv("PYTHINKER_SHARE_DIR", str(tmp_path))
+    config = Config(is_from_default_location=True)
+
+    async def fake_loopback(**_kwargs: Any) -> LoopbackAuthorization:
+        return LoopbackAuthorization("auth-code", "verifier", "http://127.0.0.1:56121/callback")
+
+    async def fake_exchange(
+        _code: str,
+        _code_verifier: str,
+        _redirect_uri: str,
+    ) -> dict[str, Any]:
+        return {
+            "access_token": access_token,
+            "refresh_token": "raw-provider-refresh-secret",
+            "expires_in": 3600,
+            "provider_diagnostic": "raw-provider-payload-secret",
+        }
+
+    monkeypatch.setattr(xai, "run_loopback_pkce_flow", fake_loopback)
+    monkeypatch.setattr(xai, "_exchange_code_for_tokens", fake_exchange)
+    _mock_unavailable_catalog(monkeypatch)
+
+    events = [event async for event in xai.login_xai_browser(config)]
+
+    assert [event.type for event in events] == ["waiting", "error"]
+    rendered_events = "\n".join(event.json for event in events)
+    assert "raw-provider-access-secret" not in rendered_events
+    assert "raw-provider-refresh-secret" not in rendered_events
+    assert "raw-provider-payload-secret" not in rendered_events
+    assert load_tokens(OAuthRef(storage="file", key="oauth/xai")) is None
+    assert "managed:xai" not in config.providers
+    assert config.models == {}
+
+
+@pytest.mark.asyncio
 async def test_login_xai_headless_rejects_missing_refresh_token(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -214,6 +214,64 @@ async def test_prompt_incremental_scrollback_uses_terminal_handoff(monkeypatch) 
     assert invalidations  # prompt is invalidated around the terminal handoff
 
 
+@pytest.mark.asyncio
+async def test_scrollback_handoff_settles_cursor_before_reexpanding(monkeypatch) -> None:
+    """Regression (doubled/ghosted running-prompt block).
+
+    After a run_in_terminal handoff the suppressed multi-row body must not
+    re-expand until the re-requested absolute-cursor CPR settles; otherwise it
+    diffs against a provisional cursor model and strands the old rows as a ghost.
+    The settle must run while the handoff is still suppressed (depth > 0), and the
+    success path must NOT reset the renderer — a reset re-fossilizes static
+    scrollback (the queued-input ghost regression).
+    """
+    from pythinker_code.ui.shell.visualize._blocks import _ContentBlock
+
+    events: list[str] = []
+    depth_at_settle: list[int] = []
+
+    class _PromptSession:
+        def invalidate(self) -> None:
+            return None
+
+    async def _run_in_terminal(func, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        func()
+
+    monkeypatch.setattr(_interactive_mod, "run_in_terminal", _run_in_terminal)
+    monkeypatch.setattr(_live_view_mod.console, "_force_terminal", True)
+    monkeypatch.setattr(
+        _live_view_mod,
+        "emit_scrollback_block",
+        lambda _console, renderable: None,
+    )
+
+    view = _PromptLiveView(
+        StatusUpdate(),
+        prompt_session=cast(Any, _PromptSession()),
+        steer=lambda _content: None,
+    )
+
+    async def _settle() -> None:
+        events.append("settle")
+        depth_at_settle.append(view._scrollback_handoff_depth)
+
+    monkeypatch.setattr(view, "_settle_cursor_after_handoff", _settle)
+    monkeypatch.setattr(
+        view, "_reset_prompt_renderer", lambda reason: events.append(f"reset:{reason}")
+    )
+    block = _ContentBlock(is_think=False)
+    block.append("First paragraph.\n\nMutable tail")
+    assert block._committed_renderables
+    view._current_content_block = block
+
+    emitted = await view._emit_incremental_content_commits()
+
+    assert emitted is True
+    assert events == ["settle"], "success path settles the cursor and never resets the renderer"
+    assert depth_at_settle == [1], "cursor settles while the handoff is still suppressed"
+    assert view._scrollback_handoff_depth == 0
+
+
 def test_status_loop_has_no_midstream_commit_throttle() -> None:
     """Regression guard: the per-tick mid-stream commit (the source of the
     run_in_terminal "jump") must not come back. Completed prose stays in the

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -326,6 +326,60 @@ async def test_scrollback_handoff_settles_cursor_on_failure(monkeypatch) -> None
     assert view._scrollback_handoff_depth == 0
 
 
+@pytest.mark.asyncio
+async def test_settle_cursor_after_handoff_behavior(monkeypatch) -> None:
+    """Exercise the real `_settle_cursor_after_handoff` against a renderer double
+    (not by mocking the method): it awaits CPR responses when the output supports
+    CPR, is a no-op otherwise, and swallows a failing CPR wait rather than
+    propagating it.
+    """
+    import prompt_toolkit.application as _pt_app
+
+    calls: list[str] = []
+
+    class _OkRenderer:
+        async def wait_for_cpr_responses(self) -> None:
+            calls.append("cpr")
+
+    class _BadRenderer:
+        async def wait_for_cpr_responses(self) -> None:
+            raise RuntimeError("cpr boom")
+
+    class _Output:
+        responds_to_cpr = True
+
+    class _App:
+        def __init__(self, renderer: object) -> None:
+            self.output = _Output()
+            self.renderer = renderer
+
+    class _PromptSession:
+        def invalidate(self) -> None:
+            return None
+
+    view = _PromptLiveView(
+        StatusUpdate(),
+        prompt_session=cast(Any, _PromptSession()),
+        steer=lambda _content: None,
+    )
+
+    # CPR supported -> awaits the renderer's CPR wait.
+    monkeypatch.setattr(_pt_app, "get_app_or_none", lambda: _App(_OkRenderer()))
+    await view._settle_cursor_after_handoff()
+    assert calls == ["cpr"]
+
+    # Output without CPR support -> no wait.
+    calls.clear()
+    _Output.responds_to_cpr = False
+    await view._settle_cursor_after_handoff()
+    assert calls == []
+
+    # A failing CPR wait is swallowed (logged), not propagated.
+    _Output.responds_to_cpr = True
+    monkeypatch.setattr(_pt_app, "get_app_or_none", lambda: _App(_BadRenderer()))
+    await view._settle_cursor_after_handoff()
+
+
 def test_status_loop_has_no_midstream_commit_throttle() -> None:
     """Regression guard: the per-tick mid-stream commit (the source of the
     run_in_terminal "jump") must not come back. Completed prose stays in the

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -272,6 +272,60 @@ async def test_scrollback_handoff_settles_cursor_before_reexpanding(monkeypatch)
     assert view._scrollback_handoff_depth == 0
 
 
+@pytest.mark.asyncio
+async def test_scrollback_handoff_settles_cursor_on_failure(monkeypatch) -> None:
+    """When the handoff emit raises, the finally block must still settle the cursor
+    (and the fail path resets the renderer) before the exception propagates — the
+    ordering guarantee that keeps the prompt recoverable after a failed handoff.
+    """
+    from pythinker_code.ui.shell.visualize._blocks import _ContentBlock
+
+    events: list[str] = []
+    depth_at_settle: list[int] = []
+
+    class _PromptSession:
+        def invalidate(self) -> None:
+            return None
+
+    async def _run_in_terminal(func, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        raise RuntimeError("emit failed")
+
+    monkeypatch.setattr(_interactive_mod, "run_in_terminal", _run_in_terminal)
+    monkeypatch.setattr(_live_view_mod.console, "_force_terminal", True)
+    monkeypatch.setattr(
+        _live_view_mod,
+        "emit_scrollback_block",
+        lambda _console, renderable: None,
+    )
+
+    view = _PromptLiveView(
+        StatusUpdate(),
+        prompt_session=cast(Any, _PromptSession()),
+        steer=lambda _content: None,
+    )
+
+    async def _settle() -> None:
+        events.append("settle")
+        depth_at_settle.append(view._scrollback_handoff_depth)
+
+    monkeypatch.setattr(view, "_settle_cursor_after_handoff", _settle)
+    monkeypatch.setattr(
+        view, "_reset_prompt_renderer", lambda reason: events.append(f"reset:{reason}")
+    )
+    block = _ContentBlock(is_think=False)
+    block.append("First paragraph.\n\nMutable tail")
+    assert block._committed_renderables
+    view._current_content_block = block
+
+    with pytest.raises(RuntimeError, match="emit failed"):
+        await view._emit_incremental_content_commits()
+
+    assert "settle" in events, "finally must settle the cursor even when the handoff raises"
+    assert "reset:handoff-fail" in events, "fail path must reset the renderer"
+    assert depth_at_settle == [1], "cursor settles while the handoff is still suppressed"
+    assert view._scrollback_handoff_depth == 0
+
+
 def test_status_loop_has_no_midstream_commit_throttle() -> None:
     """Regression guard: the per-tick mid-stream commit (the source of the
     run_in_terminal "jump") must not come back. Completed prose stays in the

--- a/tests/web/test_sessions_api.py
+++ b/tests/web/test_sessions_api.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import pytest
 from pythinker_host.path import HostPath
 
+from pythinker_code.config import OAuthRef
 from pythinker_code.session import Session
 from pythinker_code.session_state import load_session_state, save_session_state
 from pythinker_code.web.api import sessions as sessions_api
@@ -40,10 +41,10 @@ def work_dir(tmp_path: Path) -> HostPath:
 
 class _FakeOAuthManager:
     def __init__(self, _config: object) -> None:
-        pass
+        self.ensured_ref: OAuthRef | None = None
 
-    async def ensure_fresh(self) -> None:
-        return None
+    async def ensure_fresh(self, *, oauth_ref: OAuthRef | None = None) -> None:
+        self.ensured_ref = oauth_ref
 
 
 class _FakeRunner:
@@ -78,18 +79,20 @@ async def test_generate_title_preserves_concurrent_manual_title(
 ) -> None:
     session = await Session.create(work_dir)
 
+    oauth_ref = OAuthRef(storage="file", key="oauth/test-provider")
     config = SimpleNamespace(
         default_model="test-model",
         models={"test-model": SimpleNamespace(provider="test-provider")},
-        providers={"test-provider": object()},
+        providers={"test-provider": SimpleNamespace(oauth=oauth_ref)},
     )
+    oauth_manager = _FakeOAuthManager(config)
 
     monkeypatch.setattr("pythinker_code.config.load_config", lambda: config)
     monkeypatch.setattr(
         "pythinker_code.llm.create_llm",
         lambda provider_config, model_config, oauth=None: _FakeLLM(),
     )
-    monkeypatch.setattr("pythinker_code.auth.oauth.OAuthManager", _FakeOAuthManager)
+    monkeypatch.setattr("pythinker_code.auth.oauth.OAuthManager", lambda _config: oauth_manager)
 
     async def fake_generate(*, chat_provider, system_prompt, tools, history):
         state = load_session_state(session.dir)
@@ -114,3 +117,4 @@ async def test_generate_title_preserves_concurrent_manual_title(
     assert state.custom_title == "Manual Title"
     assert state.title_generated is True
     assert state.title_generate_attempts == 0
+    assert oauth_manager.ensured_ref == oauth_ref


### PR DESCRIPTION
## Summary

Consolidates two independent fixes onto one branch off `main`:

1. **PR #215 auth review remediation** — hardens the xAI / GitHub Copilot / DigitalOcean / Snowflake Cortex OAuth login providers merged in #215: scope token refresh to the active/selected provider, serialize credential persistence under a lock with atomic config replacement, roll back replaced credentials on a save failure, fail closed on credential migration, validate OAuth token and implicit-state responses, bound implicit callback bodies, and preserve router-discovery / catalog-degradation truthfulness. Adds comprehensive OAuth persistence, refresh, platform, and provider test coverage.

2. **Running-prompt "ghost" fix** — on long streaming turns the running-prompt block (agent tree, spinner, tip) could render a doubled/ghost copy. `run_in_terminal` re-requests an absolute cursor position (an async CPR round-trip) on teardown; the suppressed live body re-expanded before that settled, diffing against a provisional cursor model and stranding the old rows. It now awaits the CPR settle while the handoff is still suppressed, so the body re-expands against a correct cursor model. Unlike a renderer reset, this touches **no static scrollback**, so the #216 queued-input ghost fix stays intact (verified by its e2e test).

## Verification

- `make check-pythinker-code` — ruff + format + pyright + ty: **all pass**.
- `make test-pythinker-code` — full `tests` + `tests_e2e` suites **green** (7511 passed, 7 skipped), including the #216 queued-input regression e2e test and a new running-prompt handoff regression unit test.

## Notes

- The running-prompt ghost is a real-terminal cursor-timing race; the automated tests assert the structural fix and guard against re-regressing #216, but final visual confirmation is best done in a live terminal (Ctrl+L clears any residual — same `renderer.clear()` mechanism).
- Also gitignores `/tasks/` working files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Authentication**
  * Hardened OAuth handling with strict token validation, provider-scoped refresh, fail-closed locking, and atomic persistence with rollback (including keyring migration).
  * Improved implicit-flow callback safety: validates `Content-Length` and rejects blank access tokens.
* **Bug Fixes**
  * Fixed intermittent duplicated/“ghost” running-prompt content on long streaming turns by settling cursor state after scrollback handoff.
  * Improved managed-provider refresh so updates apply only when provider state still matches.
  * DigitalOcean router discovery now distinguishes and reports empty, malformed, and partial catalog results.
* **Reliability**
  * File locking now supports bounded waits and raises a dedicated timeout error when contention persists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->