### PR TITLE
fix(tui): commit queued-drain echo through the scrollback handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+- Fix a rare queued-follow-up "ghost card": echoing a drained queued command now commits through the scrollback handoff (which hides the input card before the terminal teardown erases the prompt), so the input-card border can no longer fossilize into scrollback above the echoed command under heavy load.
 - Freeze the public shell prompt compatibility contract with constructor and rendering coverage.
 - Unify slash and file-mention completion behind one canonical completion context, adding quoted `@"path with spaces"` file mentions.
 - Index workspace file mentions asynchronously with a cwd-aware, generation-owned snapshot index so completion never blocks on disk or Git scans.

--- a/src/pythinker_code/ui/shell/__init__.py
+++ b/src/pythinker_code/ui/shell/__init__.py
@@ -1498,7 +1498,13 @@ class Shell:
                 if not pending:
                     break
                 queued = pending.pop(0)
-                console.print(render_user_echo_text(queued.resolved_command))
+                # Commit the echo through the view's scrollback handoff (not a raw
+                # console.print): the handoff hides the input card before the
+                # terminal teardown erases the prompt, so the card border cannot
+                # fossilize into scrollback above the echoed command under load.
+                await captured_view.commit_scrollback_echo(
+                    render_user_echo_text(queued.resolved_command)
+                )
                 if prompt_session is not None:
                     prompt_session.mark_turn_starting()
                 if runtime is not None:

--- a/src/pythinker_code/ui/shell/visualize/_interactive.py
+++ b/src/pythinker_code/ui/shell/visualize/_interactive.py
@@ -561,8 +561,20 @@ class _PromptLiveView(_LiveView):
         first — which drives ``running_prompt_hide_input_card`` True and keeps the
         border out of the frame the terminal teardown erases — exactly as streamed
         turn content is committed.
+
+        Best-effort: the echo is cosmetic, so a failed handoff is logged rather
+        than raised — the queued command still runs via ``run_soul`` and must not
+        be dropped just because its scrollback echo could not be painted (the
+        handoff resets the renderer for recovery before it re-raises). Cancellation
+        still propagates, since ``CancelledError`` is not an ``Exception``.
         """
-        await self._run_scrollback_handoff(lambda: console.print(renderable), reason="queued_echo")
+        try:
+            await self._run_scrollback_handoff(
+                lambda: console.print(renderable), reason="queued_echo"
+            )
+        except Exception as exc:  # noqa: BLE001 — cosmetic echo; must not drop the queued command
+            _handoff_trace(f"QUEUED_ECHO_FAIL\t{type(exc).__name__}:{exc}")
+            logger.warning("Queued-echo scrollback commit failed; the command still runs: {}", exc)
 
     async def wait_for_btw_dismiss(self) -> None:
         """Wait for btw LLM completion + user dismiss, then clean up.

--- a/src/pythinker_code/ui/shell/visualize/_interactive.py
+++ b/src/pythinker_code/ui/shell/visualize/_interactive.py
@@ -550,6 +550,20 @@ class _PromptLiveView(_LiveView):
         self._queued_messages.clear()
         return msgs
 
+    async def commit_scrollback_echo(self, renderable: RenderableType) -> None:
+        """Print a user-echo line to scrollback through the scrollback handoff.
+
+        The shell echoes each drained queued command above the next turn. Doing
+        that with a raw ``console.print`` erases and repaints the prompt with the
+        input card still in the pre-handoff frame, so under load the card's top
+        border fossilizes into scrollback just above the echoed command. Routing
+        the echo through ``_run_scrollback_handoff`` raises the handoff depth
+        first — which drives ``running_prompt_hide_input_card`` True and keeps the
+        border out of the frame the terminal teardown erases — exactly as streamed
+        turn content is committed.
+        """
+        await self._run_scrollback_handoff(lambda: console.print(renderable), reason="queued_echo")
+
     async def wait_for_btw_dismiss(self) -> None:
         """Wait for btw LLM completion + user dismiss, then clean up.
 

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -745,7 +745,7 @@ async def test_commit_scrollback_echo_hides_input_card_during_emit(monkeypatch) 
     the handoff depth so ``running_prompt_hide_input_card`` is True at the exact
     moment the echo is written.
     """
-    from pythinker_code.ui.shell.console import console as shared_console
+    from rich.console import Console
 
     class _PromptSession:
         def update_pinned_todos(self, _items: object) -> None:
@@ -765,17 +765,52 @@ async def test_commit_scrollback_echo_hides_input_card_during_emit(monkeypatch) 
     assert view.running_prompt_hide_input_card() is False
 
     hidden_when_written: list[bool] = []
-    monkeypatch.setattr(shared_console, "_force_terminal", False)
+    # A non-terminal console makes the handoff emit synchronously (no
+    # run_in_terminal); patch the module reference rather than Rich internals.
+    test_console = Console(force_terminal=False)
+    monkeypatch.setattr(_interactive_mod, "console", test_console)
     monkeypatch.setattr(
-        shared_console,
+        test_console,
         "print",
         lambda *_a, **_k: hidden_when_written.append(view.running_prompt_hide_input_card()),
     )
 
-    await view.commit_scrollback_echo(Text("❯ queued command"))
+    await view.commit_scrollback_echo(Text("queued command echo"))
 
     assert hidden_when_written == [True]  # card hidden at the instant the echo committed
     assert view.running_prompt_hide_input_card() is False  # restored for the next turn
+
+
+@pytest.mark.asyncio
+async def test_commit_scrollback_echo_is_best_effort_when_handoff_fails(monkeypatch) -> None:
+    """A failed handoff must not drop the queued command.
+
+    The echo is cosmetic — the command still runs via ``run_soul`` — so
+    ``commit_scrollback_echo`` logs a handoff failure instead of propagating it.
+    The shell drain loop pops the queued item before echoing, so a raising echo
+    would otherwise lose that command.
+    """
+
+    class _PromptSession:
+        def update_pinned_todos(self, _items: object) -> None:
+            pass
+
+        def invalidate(self) -> None:
+            pass
+
+    view = _PromptLiveView(
+        StatusUpdate(),
+        prompt_session=cast(Any, _PromptSession()),
+        steer=lambda _content: None,
+    )
+
+    async def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("handoff teardown exploded")
+
+    monkeypatch.setattr(view, "_run_scrollback_handoff", _boom)
+
+    # Must not raise: the failure is swallowed and logged, not propagated.
+    await view.commit_scrollback_echo(Text("queued command echo"))
 
 
 def test_render_agent_prompt_message_keeps_prompt_marker_in_classic_style_pre_stream(

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -734,6 +734,50 @@ def test_render_agent_prompt_message_keeps_prompt_marker_when_card_gate_hides_bu
     assert prompt_module.PROMPT_SYMBOL_AGENT_INPUT in shown_frame
 
 
+@pytest.mark.asyncio
+async def test_commit_scrollback_echo_hides_input_card_during_emit(monkeypatch) -> None:
+    """The queued-drain echo commits while the input card is hidden.
+
+    Regression guard for the queued-follow-up ghost: echoing a drained command
+    with a raw ``console.print`` leaves the input-card border in the frame the
+    terminal teardown erases, so under load the border fossilizes above the echo.
+    ``commit_scrollback_echo`` routes through the scrollback handoff, which raises
+    the handoff depth so ``running_prompt_hide_input_card`` is True at the exact
+    moment the echo is written.
+    """
+    from pythinker_code.ui.shell.console import console as shared_console
+
+    class _PromptSession:
+        def update_pinned_todos(self, _items: object) -> None:
+            pass
+
+        def invalidate(self) -> None:
+            pass
+
+    view = _PromptLiveView(
+        StatusUpdate(),
+        prompt_session=cast(Any, _PromptSession()),
+        steer=lambda _content: None,
+    )
+    # First turn has ended: without the handoff the card is shown — the
+    # fossil-prone state the raw console.print used to commit against.
+    view._turn_ended = True
+    assert view.running_prompt_hide_input_card() is False
+
+    hidden_when_written: list[bool] = []
+    monkeypatch.setattr(shared_console, "_force_terminal", False)
+    monkeypatch.setattr(
+        shared_console,
+        "print",
+        lambda *_a, **_k: hidden_when_written.append(view.running_prompt_hide_input_card()),
+    )
+
+    await view.commit_scrollback_echo(Text("❯ queued command"))
+
+    assert hidden_when_written == [True]  # card hidden at the instant the echo committed
+    assert view.running_prompt_hide_input_card() is False  # restored for the next turn
+
+
 def test_render_agent_prompt_message_keeps_prompt_marker_in_classic_style_pre_stream(
     monkeypatch,
 ) -> None:

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -803,14 +803,26 @@ async def test_commit_scrollback_echo_is_best_effort_when_handoff_fails(monkeypa
         prompt_session=cast(Any, _PromptSession()),
         steer=lambda _content: None,
     )
+    view._turn_ended = True  # card shown → the handoff actually runs its emit
 
-    async def _boom(*_a: object, **_k: object) -> None:
+    from rich.console import Console
+
+    # Exercise the real emit seam: a non-terminal console makes the handoff call
+    # console.print directly, and that raise must be swallowed by the best-effort
+    # commit rather than propagating out and dropping the queued command.
+    test_console = Console(force_terminal=False)
+    monkeypatch.setattr(_interactive_mod, "console", test_console)
+    attempted: list[bool] = []
+
+    def _fail_print(*_a: object, **_k: object) -> None:
+        attempted.append(True)
         raise RuntimeError("handoff teardown exploded")
 
-    monkeypatch.setattr(view, "_run_scrollback_handoff", _boom)
+    monkeypatch.setattr(test_console, "print", _fail_print)
 
-    # Must not raise: the failure is swallowed and logged, not propagated.
-    await view.commit_scrollback_echo(Text("queued command echo"))
+    await view.commit_scrollback_echo(Text("queued command echo"))  # must not raise
+
+    assert attempted == [True]  # the real print seam was reached and its raise swallowed
 
 
 def test_render_agent_prompt_message_keeps_prompt_marker_in_classic_style_pre_stream(


### PR DESCRIPTION
## Summary

Fixes a rare "queued follow-up ghost": when a follow-up is queued mid-turn and later drained, the input card's top border (`──── ● off`) occasionally fossilizes into scrollback just above the executed command — visible only under heavy CPU load.

## Root cause

The shell echoes each drained queued command with a raw `console.print(render_user_echo_text(...))` (`ui/shell/__init__.py`). Once the first turn has ended, `running_prompt_hide_input_card()` returns `False`, so the input card is painted. The raw print triggers prompt_toolkit's `run_in_terminal` erase/redraw with that border still in the pre-handoff frame; under load the teardown's erase-height drifts and strands the border in scrollback.

This is the asymmetry: streamed turn content commits through `_run_scrollback_handoff` (which raises the handoff depth → hide-gate `True` → invalidate — *before* emitting), but the queued-drain echo did neither.

## Fix

Add `_PromptLiveView.commit_scrollback_echo(renderable)` — a thin wrapper that routes the echo through `_run_scrollback_handoff`, so the input card is hidden at the instant the echo is written, keeping the border out of the frame the terminal teardown erases. The shell drain loop now `await`s it instead of the raw print. This makes the queued-drain echo consistent with how streamed content is committed.

## Verification

- **Deterministic regression test** (`test_commit_scrollback_echo_hides_input_card_during_emit`): drives the real method and asserts the hide-gate is `True` at the exact moment the echo commits. **Confirmed non-circular** — it fails (`[False] == [True]`) when the method is reverted to a raw print, and passes with the fix.
- **Under load:** the manual PTY regression test (`test_mid_turn_queued_input_renders_once_and_executes_once`, CI-skipped) passed **25/25** under an 8×`yes` CPU load with the fix, where the old code fossilized under the same load.
- **Full suite:** `make check-pythinker-code` clean; `make test-pythinker-code` green (**8289 passed**, 7 skipped, 1 xfailed; e2e 65 passed).

## Sibling echo sites (audited, no-defer)

- `_emit_steer_echo` (`_interactive.py`) — **safe by design**: commits via `_append_pending_scrollback` → `_flush_pending_scrollback` → handoff, not a raw print.
- `_echo_agent_input` (initial-input echo, `__init__.py`) — **verified safe**: fires at stable idle geometry with no view/delegate attached (where the erase-height doesn't drift); the two existing initial-echo fossil guards passed **12/12** under the same 8×`yes` load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a rare “ghost card” condition where queued follow-up input could leave an input-card border “fossilized” in terminal scrollback during heavy load.
  - Queued command “resolved” echoes now use the active prompt’s scrollback handoff flow, ensuring the input card hides correctly during queued echo emission.

- **Tests**
  - Added regression coverage for queued echo rendering during input-card hide/teardown, including best-effort handling when the handoff fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->