### PR TITLE
chore(release): prepare 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.62.0 (2026-07-22)
+
 - Treat the repository-root `.agents/` directory as local agent configuration and keep it out of version control.
 - Show an update notice when a newer Pythinker version becomes available mid-session.
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ---
 
-## 🆕 What's New in 0.61.0
+## 🆕 What's New in 0.62.0
 
 - **A faster, steadier interactive prompt.** Slash commands and file mentions now share one completion engine, workspace indexing runs asynchronously, prompt resources are isolated per session, and awaited lifecycle cleanup prevents stale background work. The prompt also stays within the terminal height and avoids queued-input ghost borders.
 - **More provider login options with safer persistence.** Pythinker adds OAuth login for xAI Grok, GitHub Copilot, DigitalOcean Gradient AI, and Snowflake Cortex, backed by a provider-neutral models.dev catalog with curated fallbacks. Credential changes are saved atomically and rolled back if persistence fails.
 - **Cleaner reasoning and agent activity.** Reasoning summaries no longer expose Markdown delimiters or duplicate terminal rows after refocus, while individual agents and parallel `RunAgents` calls render as a compact, payload-free activity tree with correctly nested subagent work.
 
-Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.61.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.62.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 
 ---
@@ -162,7 +162,7 @@ matches your OS — no Python, Node, or `uv` prerequisite.
 
 | Platform | Recommended install | Artifact source |
 |---|---|---|
-| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.61.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
+| **🪟 Windows** | `irm https://pythinker.com/install.ps1 \| iex` | `PythinkerSetup-0.62.0.exe` from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> / <img src="https://img.shields.io/badge/-Linux-FCC624?style=flat-square&logo=linux&logoColor=black" alt="Linux">** | `curl -fsSL https://pythinker.com/install.sh \| bash` | native tarball from [Releases](https://github.com/Pythoughts-labs/pythinker-code/releases/latest) |
 | **<img src="https://img.shields.io/badge/-macOS-000000?style=flat-square&logo=apple&logoColor=white" alt="macOS"> — Homebrew** | `brew install Pythoughts-labs/pythinker/pythinker-code` | auto-published Homebrew tap |
 | **🐳 Docker** | `docker run --rm -it ghcr.io/pythoughts-labs/pythinker-code` | GHCR multi-arch image |
@@ -190,7 +190,7 @@ pythinker                      # start the interactive TUI
 
 ### 🪟 Windows — native installer
 
-`PythinkerSetup-0.61.0.exe` is an Inno Setup wizard. Release builds are signed
+`PythinkerSetup-0.62.0.exe` is an Inno Setup wizard. Release builds are signed
 when Authenticode secrets are configured in CI; otherwise the installer ships
 unsigned. Installs per-user into `%LOCALAPPDATA%\Programs\Pythinker`, registers
 `pythinker` on your user PATH (`HKCU\Environment`), broadcasts
@@ -202,13 +202,13 @@ irm https://pythinker.com/install.ps1 | iex
 
 # Or manually download the installer + checksum from the Releases page,
 # verify with Get-FileHash, then run:
-.\PythinkerSetup-0.61.0.exe
+.\PythinkerSetup-0.62.0.exe
 
 # Open a fresh PowerShell
 pythinker --version
 ```
 
-**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.61.0.exe /ALLUSERS`
+**Per-machine install** (IT-managed boxes): `.\PythinkerSetup-0.62.0.exe /ALLUSERS`
 installs to `%ProgramFiles%\Pythinker` and writes PATH to HKLM (requires admin).
 
 **Upgrade:** `pythinker update` from inside the running app — it downloads
@@ -266,26 +266,26 @@ attached to every GitHub Release.
 
 ```sh
 # Debian / Ubuntu (x86_64)
-sudo dpkg -i pythinker-code_0.61.0_amd64.deb
+sudo dpkg -i pythinker-code_0.62.0_amd64.deb
 sudo apt-get install -f       # only if dpkg reports missing deps
 
 # Debian / Ubuntu (ARM64)
-sudo dpkg -i pythinker-code_0.61.0_arm64.deb
+sudo dpkg -i pythinker-code_0.62.0_arm64.deb
 
 # Fedora / RHEL / openSUSE (x86_64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code-0.61.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code-0.61.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.61.0.x86_64.rpm.sha256
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code-0.62.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code-0.62.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.62.0.x86_64.rpm.sha256
 # Fedora / RHEL:
-sudo dnf install ./pythinker-code-0.61.0.x86_64.rpm
+sudo dnf install ./pythinker-code-0.62.0.x86_64.rpm
 # openSUSE:
-sudo zypper install ./pythinker-code-0.61.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.62.0.x86_64.rpm
 
 # Fedora / RHEL (aarch64)
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code-0.61.0.aarch64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code-0.61.0.aarch64.rpm.sha256
-sha256sum -c pythinker-code-0.61.0.aarch64.rpm.sha256
-sudo dnf install ./pythinker-code-0.61.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code-0.62.0.aarch64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code-0.62.0.aarch64.rpm.sha256
+sha256sum -c pythinker-code-0.62.0.aarch64.rpm.sha256
+sudo dnf install ./pythinker-code-0.62.0.aarch64.rpm
 ```
 
 Both packages drop a small `/usr/bin/pythinker` launcher that execs the real
@@ -294,8 +294,8 @@ binary under `/usr/lib/pythinker/`, so your `$PATH` stays tidy.
 **Verify before install:**
 
 ```sh
-sha256sum -c pythinker-code_0.61.0_amd64.deb.sha256        # Debian/Ubuntu
-sha256sum -c pythinker-code-0.61.0.x86_64.rpm.sha256       # Fedora/RHEL
+sha256sum -c pythinker-code_0.62.0_amd64.deb.sha256        # Debian/Ubuntu
+sha256sum -c pythinker-code-0.62.0.x86_64.rpm.sha256       # Fedora/RHEL
 ```
 
 **Upgrade:** download the new `.deb`/`.rpm` from Releases and `dpkg -i` /

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -44,7 +44,7 @@ On Windows, run the PowerShell bootstrap. It downloads the native installer, ver
 irm https://pythinker.com/install.ps1 | iex
 ```
 
-You can also download `PythinkerSetup-0.61.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
+You can also download `PythinkerSetup-0.62.0.exe` manually from the [latest release](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 
 Verify the installation:
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,8 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## Unreleased
 
+## 0.62.0 (2026-07-22)
+
 ## 0.61.0 (2026-07-22)
 
 Shell-mode `!` commands now run through the configured shell (`<shell> -c`, or PowerShell

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,6 +17,11 @@ GitHub Releases page; `0.8.0` is the new starting line.
 
 ## Unreleased
 
+## 0.62.0 (2026-07-22)
+
+- Treat the repository-root `.agents/` directory as local agent configuration and keep it out of version control.
+- Show an update notice when a newer Pythinker version becomes available mid-session.
+
 ## 0.61.0 (2026-07-22)
 
 - Fixed reasoning summaries exposing Markdown delimiters and duplicate terminal rows after refocus, and redesigned agent progress (single `Agent` calls and parallel `RunAgents` fan-outs) as a compact, payload-free agent activity tree.

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -8,19 +8,19 @@ End-user install from the current GitHub Release:
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code_0.61.0_amd64.deb
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code_0.61.0_amd64.deb.sha256
-sha256sum -c pythinker-code_0.61.0_amd64.deb.sha256
-sudo dpkg -i pythinker-code_0.61.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code_0.62.0_amd64.deb
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code_0.62.0_amd64.deb.sha256
+sha256sum -c pythinker-code_0.62.0_amd64.deb.sha256
+sudo dpkg -i pythinker-code_0.62.0_amd64.deb
 sudo apt-get install -f       # only needed if dependencies fail to resolve
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code-0.61.0.x86_64.rpm
-curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.61.0/pythinker-code-0.61.0.x86_64.rpm.sha256
-sha256sum -c pythinker-code-0.61.0.x86_64.rpm.sha256
-sudo dnf install ./pythinker-code-0.61.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code-0.62.0.x86_64.rpm
+curl -LO https://github.com/Pythoughts-labs/pythinker-code/releases/download/v0.62.0/pythinker-code-0.62.0.x86_64.rpm.sha256
+sha256sum -c pythinker-code-0.62.0.x86_64.rpm.sha256
+sudo dnf install ./pythinker-code-0.62.0.x86_64.rpm
 # or, on openSUSE:
-sudo zypper install ./pythinker-code-0.61.0.x86_64.rpm
+sudo zypper install ./pythinker-code-0.62.0.x86_64.rpm
 ```
 
 The package drops a single executable at `/usr/bin/pythinker` and a license
@@ -41,8 +41,8 @@ bash packages/linux-installer/build.sh 0.60.0
 
 Outputs to `dist/`:
 
-- `pythinker-code_0.61.0_amd64.deb`
-- `pythinker-code-0.61.0.x86_64.rpm`
+- `pythinker-code_0.62.0_amd64.deb`
+- `pythinker-code-0.62.0.x86_64.rpm`
 
 The portable tarball used by `scripts/install-native.sh` is published by
 the existing `release-pythinker-cli.yml` workflow under the cargo-dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythinker-code"
-version = "0.61.0"
+version = "0.62.0"
 description = "Pythinker — an agentic CLI developed by Pythoughts-labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2527,7 +2527,7 @@ wheels = [
 
 [[package]]
 name = "pythinker-code"
-version = "0.61.0"
+version = "0.62.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Related Issue

N/A — scheduled root Pythinker CLI release.

## Description

- Prepare the root pythinker-code CLI release as version 0.62.0.
- Promote the authored Unreleased changelog entries into the dated 0.62.0 section.
- Regenerate the documentation changelog and update version-derived README, installer, pyproject, and lockfile references.
- Do not bump independently versioned packages under packages or sdks.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked the related issue, if any. No issue applies to this release-preparation PR.
- [x] I have added tests that prove my fix is effective or that my feature works. Release automation passed version/dependency gates and 9 lockstep tests; pre-push hooks passed the full check and test suites.
- [x] I have run make gen-changelog to update the changelog. The release orchestrator promoted CHANGELOG.md and ran the authoritative docs changelog sync directly.
- [x] I have run make gen-docs to update the user documentation. The release orchestrator updated the affected generated and version-derived documentation.