### PR TITLE
fix(release): correct 0.62.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ It speaks the [**Agent Client Protocol (ACP)**](https://github.com/agentclientpr
 
 ## 🆕 What's New in 0.62.0
 
-- **A faster, steadier interactive prompt.** Slash commands and file mentions now share one completion engine, workspace indexing runs asynchronously, prompt resources are isolated per session, and awaited lifecycle cleanup prevents stale background work. The prompt also stays within the terminal height and avoids queued-input ghost borders.
-- **More provider login options with safer persistence.** Pythinker adds OAuth login for xAI Grok, GitHub Copilot, DigitalOcean Gradient AI, and Snowflake Cortex, backed by a provider-neutral models.dev catalog with curated fallbacks. Credential changes are saved atomically and rolled back if persistence fails.
-- **Cleaner reasoning and agent activity.** Reasoning summaries no longer expose Markdown delimiters or duplicate terminal rows after refocus, while individual agents and parallel `RunAgents` calls render as a compact, payload-free activity tree with correctly nested subagent work.
+- **Updates surface during long-running sessions.** Pythinker now checks periodically for newly available releases, shows each new update notice once per session, and bounds every check with a watchdog so a stalled attempt cannot prevent later retries.
+- **Repository-local agent workflows stay local.** This checkout now treats its root `.agents/` directory as local agent configuration instead of version-controlled project content.
 
 Upgrade with `pythinker update`, `pip install --upgrade pythinker-code==0.62.0`, or use the native installer for your platform from the [Releases page](https://github.com/Pythoughts-labs/pythinker-code/releases/latest).
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -6,6 +6,8 @@ This page documents breaking changes in Pythinker Code releases and provides mig
 
 ## 0.62.0 (2026-07-22)
 
+No breaking changes.
+
 ## 0.61.0 (2026-07-22)
 
 Shell-mode `!` commands now run through the configured shell (`<shell> -c`, or PowerShell

--- a/packages/linux-installer/README.md
+++ b/packages/linux-installer/README.md
@@ -36,7 +36,7 @@ file at `/usr/share/doc/pythinker-code/LICENSE`.
 ## Build
 
 ```sh
-bash packages/linux-installer/build.sh 0.60.0
+bash packages/linux-installer/build.sh 0.62.0
 ```
 
 Outputs to `dist/`:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -132,7 +132,10 @@ def promote_changelog(path: Path, version: str, *, release_date: str) -> None:
 
 
 def rewrite_version_strings(text: str, *, old: str, new: str) -> str:
-    """Replace ONLY release-pattern occurrences of `old` with `new`.
+    """Update release-pattern versions to `new`.
+
+    Most patterns replace `old`; canonical version-bearing commands are
+    normalized even when their current version is already stale.
 
     Deliberately skips `--version <old>` flag examples (the documented
     §3 exception) so they stay shape-only — the lockstep test enforces this.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -145,6 +145,10 @@ def rewrite_version_strings(text: str, *, old: str, new: str) -> str:
         (rf"(pythinker-code_){o}(_[a-z0-9]+\.deb)", rf"\g<1>{new}\g<2>"),
         (rf"(pythinker-code-){o}(\.[a-z0-9_]+\.rpm)", rf"\g<1>{new}\g<2>"),
         (rf"(releases/download/v){o}(/)", rf"\g<1>{new}\g<2>"),
+        (
+            r"(bash packages/linux-installer/build\.sh )\d+\.\d+\.\d+",
+            rf"\g<1>{new}",
+        ),
     ]
     for pat, repl in patterns:
         text = re.sub(pat, repl, text)

--- a/tests/test_release_py.py
+++ b/tests/test_release_py.py
@@ -250,6 +250,7 @@ def test_rewrite_version_strings_targets_only_release_patterns() -> None:
         "pythinker-code_0.27.0_amd64.deb\n"
         "pythinker-code-0.27.0.x86_64.rpm\n"
         "releases/download/v0.27.0/pythinker-code_0.27.0_arm64.deb\n"
+        "bash packages/linux-installer/build.sh 0.26.0\n"
         "bash -s -- --version 0.27.0\n"  # flag example: MUST be preserved
     )
     out = release_tool.rewrite_version_strings(text, old="0.27.0", new="0.28.0")
@@ -259,6 +260,7 @@ def test_rewrite_version_strings_targets_only_release_patterns() -> None:
     assert "pythinker-code_0.28.0_amd64.deb" in out
     assert "pythinker-code-0.28.0.x86_64.rpm" in out
     assert "releases/download/v0.28.0/pythinker-code_0.28.0_arm64.deb" in out
+    assert "bash packages/linux-installer/build.sh 0.28.0" in out
     # the flag example is the documented exception — untouched
     assert "--version 0.27.0" in out
     assert "--version 0.28.0" not in out

--- a/tests/test_version_lockstep.py
+++ b/tests/test_version_lockstep.py
@@ -88,6 +88,13 @@ def test_asset_names_match_version_across_files() -> None:
                 assert found == VERSION, f"{path}: {found} != {VERSION}"
 
 
+def test_linux_installer_build_example_matches_version() -> None:
+    readme = (REPO_ROOT / "packages" / "linux-installer" / "README.md").read_text(encoding="utf-8")
+    versions = re.findall(r"bash packages/linux-installer/build\.sh (\d+\.\d+\.\d+)", readme)
+    assert versions, "missing Linux installer build example"
+    assert versions == [VERSION]
+
+
 def test_no_hardcoded_version_badge_in_readme() -> None:
     # Guard the contract's "badges" clause: the only version-bearing badge is the
     # shields.io-live PyPI badge (img.shields.io/pypi/v/...). Fail if a future edit


### PR DESCRIPTION
## Related Issue

N/A — release correction.

## Description

- Replace stale 0.61 README highlights with the actual 0.62 changes.
- Correct the Linux installer build example and harden the release rewrite and lockstep test.
- State explicitly that 0.62.0 has no breaking changes.

## Verification

- Confirmed the new regression tests failed before the implementation change.
- uv run pytest tests/test_release_py.py tests/test_version_lockstep.py -q — 26 passed.
- Commit hooks passed.
- Full pre-push gate passed: formatting, lint, make check-pythinker-code, and make test-pythinker-code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic release update notifications in long-running sessions, showing each notice once and avoiding stalled checks.
  * Updated checkout handling so the root `.agents/` directory is treated as local configuration.

* **Documentation**
  * Updated Linux installer build instructions to use version **0.62.0**.

* **Chores**
  * Enhanced release tooling to normalize version strings in Linux installer build commands.
  * Added tests to verify the installer documentation examples stay in lockstep with the repository version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[skip changelog]